### PR TITLE
Added Decay support for bxt_autostop

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1167,6 +1167,7 @@ HOOK_DEF_2(ServerDLL, void, __fastcall, CMultiManager__ManagerThink, void*, this
 			const char *targetname = (*ppGlobals)->pStringBase + pev->targetname;
 			if (!std::strcmp(targetname, "roll_the_credits")
 				|| !std::strcmp(targetname, "youwinmulti")
+				|| !std::strcmp(targetname, "previctory_mm")
 				|| !std::strcmp(targetname, "stairscene_mngr")) {
 				if (CVars::bxt_timer_autostop.GetBool())
 					CustomHud::SetCountingTime(false);


### PR DESCRIPTION
According to the leaderboard, time occurs on the first frame of the alienflyer's explosion. On death, monster_alienflyer triggers previctory_mm. Extensive testing and map extracting has confirmed that this is the only instance where previctory_mm is triggered, with no unintended side effects.