### PR TITLE
Add bxt_collision_depth_map_pixel_scale for rendering the collision map at lower resolutions

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -54,6 +54,7 @@ namespace CVars
 	CVarWrapper bxt_collision_depth_map_colors("bxt_collision_depth_map_colors", "0");
 	CVarWrapper bxt_collision_depth_map_hull("bxt_collision_depth_map_hull", "2");
 	CVarWrapper bxt_collision_depth_map_max_depth("bxt_collision_depth_map_max_depth", "500");
+	CVarWrapper bxt_collision_depth_map_pixel_scale("bxt_collision_depth_map_pixel_scale", "1");
 	CVarWrapper bxt_unlock_camera_during_pause("bxt_unlock_camera_during_pause", "0");
 	CVarWrapper bxt_hud("bxt_hud", "1");
 	CVarWrapper bxt_hud_color("bxt_hud_color", "");
@@ -144,6 +145,7 @@ namespace CVars
 		&bxt_collision_depth_map_colors,
 		&bxt_collision_depth_map_hull,
 		&bxt_collision_depth_map_max_depth,
+		&bxt_collision_depth_map_pixel_scale,
 		&bxt_unlock_camera_during_pause,
 		&bxt_hud,
 		&bxt_hud_color,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -161,6 +161,7 @@ namespace CVars
 	extern CVarWrapper bxt_collision_depth_map_colors;
 	extern CVarWrapper bxt_collision_depth_map_hull;
 	extern CVarWrapper bxt_collision_depth_map_max_depth;
+	extern CVarWrapper bxt_collision_depth_map_pixel_scale;
 	extern CVarWrapper bxt_unlock_camera_during_pause;
 	extern CVarWrapper bxt_hud;
 	extern CVarWrapper bxt_hud_color;

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -879,9 +879,11 @@ namespace CustomHud
 			glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+			const auto pixel_scale = CVars::bxt_collision_depth_map_pixel_scale.GetInt();
+
 			// Main loop.
-			for (int y = 0; y < si.iHeight; ++y) {
-				for (int x = 0; x < si.iWidth; ++x) {
+			for (int y = 0; y < si.iHeight; y += pixel_scale) {
+				for (int x = 0; x < si.iWidth; x += pixel_scale) {
 					// Horizontal angle.
 					const auto l = std::sqrt(x * x + a_sq - 2 * x * a * cos_alpha);
 					auto theta = std::asin(sin_alpha * x / l);
@@ -918,20 +920,22 @@ namespace CustomHud
 						const auto make_color = [](const unsigned char value[4]) {
 							return value[0] ^ value[1] ^ value[2] ^ value[3];
 						};
-						glColor4ub(make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[0])),
-						           make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[1])),
-						           make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[2])),
-						           255);
-					} else {
+						glColor4ub(
+							make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[0])),
+							make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[1])),
+							make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[2])),
+							255);
+					}
+					else {
 						const auto value = 255 - static_cast<int>(std::round(result.Fraction * 255));
 						glColor4ub(value, value, value, 255);
 					}
 
 					glBegin(GL_QUADS);
 					glVertex2i(x, y);
-					glVertex2i(x, y + 1);
-					glVertex2i(x + 1, y + 1);
-					glVertex2i(x + 1, y);
+					glVertex2i(x, y + pixel_scale);
+					glVertex2i(x + pixel_scale, y + pixel_scale);
+					glVertex2i(x + pixel_scale, y);
 					glEnd();
 				}
 			}

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -844,21 +844,14 @@ namespace CustomHud
 			// Arbitrary sanity clamps.
 			const auto max_depth = std::max(CVars::bxt_collision_depth_map_max_depth.GetFloat(), 10.f);
 
-			// Some horizontal constants.
-			const auto fov = std::clamp(CVars::default_fov.GetFloat(), 30.f, 150.f) * M_DEG2RAD;
-			const auto alpha = float(M_PI_2) - fov / 2;
-			const auto cos_alpha = std::cos(alpha);
-			const auto sin_alpha = std::sin(alpha);
-			const auto a = si.iWidth / std::sin(fov) * sin_alpha;
-			const auto a_sq = a * a;
+			// Some constants.
+			const float aspect_ratio = (float)si.iHeight / (float)si.iWidth;
 
-			// Some vertical constants.
-			const auto b_sq = a * a - (si.iWidth * si.iWidth - si.iHeight * si.iHeight) / 4.f;
-			const auto b = std::sqrt(b_sq);
-			const auto vfov = std::acos(1 - (si.iHeight * si.iHeight) / (2 * b_sq));
-			const auto beta = float(M_PI_2) - vfov / 2;
-			const auto cos_beta = std::cos(beta);
-			const auto sin_beta = std::sin(beta);
+			const auto fov = std::clamp(CVars::default_fov.GetFloat(), 30.f, 150.f) * M_DEG2RAD;
+			const auto vfov = 2.f * std::atan(std::tan(fov * 0.5f) * aspect_ratio);
+
+			const float screen_width = max_depth * (float) std::tan(fov * 0.5);
+			const float screen_height = max_depth * (float) std::tan(vfov * 0.5);
 
 			// The trace starting point and forward vector.
 			float start[3];
@@ -883,34 +876,17 @@ namespace CustomHud
 
 			// Main loop.
 			for (int y = 0; y < si.iHeight; y += pixel_scale) {
+				// -1 <= y_offset <= 1
+				const float y_offset = -((float)y / (float)si.iHeight - 0.5f) * 2.f;
+
 				for (int x = 0; x < si.iWidth; x += pixel_scale) {
-					// Horizontal angle.
-					const auto l = std::sqrt(x * x + a_sq - 2 * x * a * cos_alpha);
-					auto theta = std::asin(sin_alpha * x / l);
-					// Law of sines ambiguity.
-					if (x * x > a * a + l * l)
-						theta += 2 * (float(M_PI_2) - theta);
-					const auto hor_angle = -(fov / 2 - theta);
+					// -1 <= x_offset <= 1
+					const float x_offset = ((float)x / (float)si.iWidth - 0.5f) * 2.f;
 
-					// Vertical angle.
-					const auto vl = std::sqrt(y * y + b_sq - 2 * y * b * cos_beta);
-					auto phi = std::asin(sin_beta * y / vl);
-					// Law of sines ambiguity.
-					if (y * y > b_sq + vl * vl)
-						phi += 2 * (float(M_PI_2) - phi);
-					const auto vert_angle = vfov / 2 - phi;
-
-					// End position.
-					const float new_forward[3] = {
-						forward[0] + right[0] * hor_angle + up[0] * vert_angle,
-						forward[1] + right[1] * hor_angle + up[1] * vert_angle,
-						forward[2] + right[2] * hor_angle + up[2] * vert_angle
-					};
-					const auto new_forward_len = std::sqrt(new_forward[0] * new_forward[0] + new_forward[1] * new_forward[1] + new_forward[2] * new_forward[2]);
 					const float end[3] = {
-						start[0] + new_forward[0] / new_forward_len * max_depth,
-						start[1] + new_forward[1] / new_forward_len * max_depth,
-						start[2] + new_forward[2] / new_forward_len * max_depth
+						start[0] + forward[0] * max_depth + screen_width * x_offset * right[0] + screen_height * y_offset * up[0],
+						start[1] + forward[1] * max_depth + screen_width * x_offset * right[1] + screen_height * y_offset * up[1],
+						start[2] + forward[2] * max_depth + screen_width * x_offset * right[2] + screen_height * y_offset * up[2],
 					};
 
 					// Trace.
@@ -925,8 +901,7 @@ namespace CustomHud
 							make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[1])),
 							make_color(reinterpret_cast<const unsigned char*>(&result.PlaneNormal[2])),
 							255);
-					}
-					else {
+					} else {
 						const auto value = 255 - static_cast<int>(std::round(result.Fraction * 255));
 						glColor4ub(value, value, value, 255);
 					}

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -2432,6 +2432,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_collision_depth_map_colors);
 	RegisterCVar(CVars::bxt_collision_depth_map_hull);
 	RegisterCVar(CVars::bxt_collision_depth_map_max_depth);
+	RegisterCVar(CVars::bxt_collision_depth_map_pixel_scale);
 
 	CVars::sv_cheats.Assign(FindCVar("sv_cheats"));
 	CVars::fps_max.Assign(FindCVar("fps_max"));


### PR DESCRIPTION
Right now, using the collision depth map of BXT is very slow at high resolutions. This PR adds the console variable `bxt_collision_depth_map_pixel_scale` which indicates the size of each traced pixel (i.e. a pixel scale of 4 would mean that a single ray is cast for a 4x4 area, instead of the old 1 ray per pixel). 

PR also includes a rewrite of the code that calculates the camera rays, which is both simpler and fixes the old depth map not completely lining up with the normal HL render. The view was especially warped when looking at walls at a shallow angle, which is now fixed.