### PR TITLE
Add +/-bxt_triggers_place

### DIFF
--- a/BunnymodXT/custom_triggers.cpp
+++ b/BunnymodXT/custom_triggers.cpp
@@ -7,6 +7,8 @@
 namespace CustomTriggers
 {
 	std::vector<Trigger> triggers;
+	Vector place_start;
+	bool placing = false;
 
 	void Trigger::normalize()
 	{
@@ -72,6 +74,13 @@ namespace CustomTriggers
 			if (last_char != '\n' && last_char != ';')
 				command += '\n';
 		}
+	}
+
+	void Trigger::set_corner_positions(Vector corner1, Vector corner2)
+	{
+		corner_min = corner1;
+		corner_max = corner2;
+		normalize();
 	}
 
 	void Trigger::update(const Vector& player_position, bool ducking)
@@ -171,6 +180,20 @@ namespace CustomTriggers
 	{
 		for (auto& trigger : triggers)
 			trigger.update(player_position, ducking);
+
+		if (placing) {
+			if (!triggers.empty())
+			{
+				auto trace = HwDLL::GetInstance().CameraTrace();
+				Vector place_end(trace.EndPos);
+
+				triggers.back().set_corner_positions(place_start, place_end);
+			}
+			else
+			{
+				placing = false;
+			}
+		}
 	}
 
 	void Update(const Vector& player_position_start, const Vector& player_position_end, bool ducking)

--- a/BunnymodXT/custom_triggers.hpp
+++ b/BunnymodXT/custom_triggers.hpp
@@ -26,6 +26,7 @@ namespace CustomTriggers
 		std::pair<Vector, Vector> get_corner_positions() const;
 		const std::string& get_command() const;
 		void set_command(std::string new_command);
+		void set_corner_positions(Vector a, Vector b);
 
 		void update(const Vector& player_position, bool ducking);
 
@@ -37,6 +38,11 @@ namespace CustomTriggers
 	};
 
 	extern std::vector<Trigger> triggers;
+
+	// We need to keep track of the placement start because the Trigger.normalize()
+	// can cause the start and end points to be swapped.
+	extern Vector place_start;
+	extern bool placing;
 
 	void Update(const Vector& player_position, bool ducking);
 	void Update(const Vector& player_position_start, const Vector& player_position_end, bool ducking);

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -199,6 +199,7 @@ public:
 	}
 
 	HLStrafe::TraceResult PlayerTrace(const float start[3], const float end[3], HLStrafe::HullType hull, bool extendDistanceLimit = false);
+	HLStrafe::TraceResult CameraTrace(float max_distance = 8192);
 
 	// Don't call StartTrace() or StopTracing() twice in a row.
 	// The sequence must always be StartTracing() => StopTracing().
@@ -328,6 +329,8 @@ protected:
 	struct Cmd_BXT_Triggers_Export;
 	struct Cmd_BXT_Triggers_List;
 	struct Cmd_BXT_Triggers_SetCommand;
+	struct Cmd_BXT_Triggers_Place_Up;
+	struct Cmd_BXT_Triggers_Place_Down;
 	struct Cmd_BXT_Record;
 	struct Cmd_BXT_AutoRecord;
 	struct Cmd_BXT_Interprocess_Reset;


### PR DESCRIPTION
# Usage
This PR add +bxt_triggers_place and -bxt_triggers_place. These allow easier placement of custom triggers by simply looking at the begin point and end point of the trigger to be created (+bxt_triggers_place indicates the starting point of the trigger and -bxt_triggers_place indicates the end point). 

Video demonstration: https://streamable.com/nnrwl

# Code
The code isn't great at the moment, adding two globals to the `custom_triggers.hpp` file. This is somewhat due to the already present structure of maintaining the custom triggers. In case the code is not fine like this, I was working on a small rewrite of the custom triggers in my custom_triggers_rewrite branch which I could append to this PR when it is done.