### PR TITLE
Add pickable items absmin absmax drawing

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -41,6 +41,7 @@ namespace CVars
 	CVarWrapper bxt_timer_autostop("bxt_timer_autostop", "1");
 	CVarWrapper bxt_show_hidden_entities("bxt_show_hidden_entities", "0");
 	CVarWrapper bxt_show_triggers_legacy("bxt_show_triggers_legacy", "0");
+	CVarWrapper bxt_show_pickup_bbox("bxt_show_pickup_bbox", "0");
 
 	// Clientside CVars
 	CVarWrapper bxt_autojump_prediction("bxt_autojump_prediction", "0");
@@ -145,6 +146,7 @@ namespace CVars
 		&bxt_autojump_prediction,
 		&bxt_bhopcap_prediction,
 		&bxt_show_nodes,
+		&bxt_show_pickup_bbox,
 		&bxt_show_custom_triggers,
 		&bxt_wallhack,
 		&bxt_wallhack_additive,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -148,6 +148,7 @@ namespace CVars
 	extern CVarWrapper bxt_timer_autostop;
 	extern CVarWrapper bxt_show_hidden_entities;
 	extern CVarWrapper bxt_show_triggers_legacy;
+	extern CVarWrapper bxt_show_pickup_bbox;
 
 	// Clientside CVars
 	extern CVarWrapper bxt_autojump_prediction;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -435,6 +435,7 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_show_triggers);
 		REG(bxt_show_custom_triggers);
 		REG(bxt_show_nodes);
+		REG(bxt_show_pickup_bbox);
 		REG(bxt_hud_useables);
 		REG(bxt_hud_useables_radius);
 	}


### PR DESCRIPTION
`bxt_show_pickable_bbox 0|1|2`

Setting `2` will draw the faces for the player's absmin and absmax, useful to look at intersections more clearly and in third person.

![bbox-1](https://user-images.githubusercontent.com/2558060/93018479-947fea80-f602-11ea-96c5-7b9ce01a6dac.jpg)
![bbox-2](https://user-images.githubusercontent.com/2558060/93018480-95b11780-f602-11ea-9092-fe36c1017680.jpg)
