### PR TITLE
Fixed incorrect position for bxt_hud_entity_info

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -658,7 +658,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_entity_info.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_entity_info_offset, CVars::bxt_hud_entity_info_anchor, &x, &y, -250, (si.iCharHeight * 16) + 3);
+			GetPosition(CVars::bxt_hud_entity_info_offset, CVars::bxt_hud_entity_info_anchor, &x, &y, -200, (si.iCharHeight * 16) + 3);
 
 			const auto& hw = HwDLL::GetInstance();
 			const auto& sv = ServerDLL::GetInstance();


### PR DESCRIPTION
Before: 

![before](https://user-images.githubusercontent.com/58108407/99886760-7b299900-2c58-11eb-8033-37ba05be2816.png)

Now:

![now](https://user-images.githubusercontent.com/58108407/99886767-841a6a80-2c58-11eb-91b1-6b9a7877b461.png)

