### PR TITLE
Added bxt_ch_set_angles

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -579,12 +579,6 @@ void HwDLL::FindStuff()
 		else
 			EngineDevWarning("[hw dll] Could not find hudGetViewAngles.\n");
 
-		ORIG_hudSetViewAngles = reinterpret_cast<_hudSetViewAngles>(MemUtils::GetSymbolAddress(m_Handle, "hudSetViewAngles"));
-		if (ORIG_hudSetViewAngles)
-			EngineDevMsg("[hw dll] Found hudSetViewAngles at %p.\n", ORIG_hudSetViewAngles);
-		else
-			EngineDevWarning("[hw dll] Could not find hudSetViewAngles.\n");
-
 		ORIG_SV_AddLinksToPM = reinterpret_cast<_SV_AddLinksToPM>(MemUtils::GetSymbolAddress(m_Handle, "SV_AddLinksToPM"));
 		if (ORIG_SV_AddLinksToPM)
 			EngineDevMsg("[hw dll] Found SV_AddLinksToPM at %p.\n", ORIG_SV_AddLinksToPM);
@@ -3975,12 +3969,10 @@ void HwDLL::GetViewangles(float* va)
 
 void HwDLL::SetViewangles(float* va)
 {
-	if (!ORIG_hudSetViewAngles) {
-	    ClientDLL::GetInstance().pEngfuncs->SetViewAngles(va);
-	} else
-		ORIG_hudSetViewAngles(va);
+	if (ClientDLL::GetInstance().pEngfuncs) {
+		ClientDLL::GetInstance().pEngfuncs->SetViewAngles(va);
+	}
 }
-
 
 HLStrafe::TraceResult HwDLL::PlayerTrace(const float start[3], const float end[3], HLStrafe::HullType hull, bool extendDistanceLimit)
 {

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -296,8 +296,6 @@ protected:
 	_Cmd_Argv ORIG_Cmd_Argv;
 	typedef void(__cdecl *_hudGetViewAngles) (float* va);
 	_hudGetViewAngles ORIG_hudGetViewAngles;
-	typedef void(__cdecl *_hudSetViewAngles) (float* va);
-	_hudSetViewAngles ORIG_hudSetViewAngles;
 	typedef pmtrace_t(__cdecl *_PM_PlayerTrace) (const float* start, const float* end, int traceFlags, int ignore_pe);
 	_PM_PlayerTrace ORIG_PM_PlayerTrace;
 	typedef void(__cdecl *_SV_AddLinksToPM) (char* node, float* origin);

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -140,6 +140,7 @@ public:
 	void SetPlayerVelocity(float velocity[3]);
 	bool TryGettingAccurateInfo(float origin[3], float velocity[3], float& health);
 	void GetViewangles(float* va);
+	void SetViewangles(float* va);
 
 	inline bool GetIsOverridingCamera() const { return isOverridingCamera; }
 	inline void GetCameraOverrideOrigin(float origin[3]) const
@@ -295,6 +296,8 @@ protected:
 	_Cmd_Argv ORIG_Cmd_Argv;
 	typedef void(__cdecl *_hudGetViewAngles) (float* va);
 	_hudGetViewAngles ORIG_hudGetViewAngles;
+	typedef void(__cdecl *_hudSetViewAngles) (float* va);
+	_hudSetViewAngles ORIG_hudSetViewAngles;
 	typedef pmtrace_t(__cdecl *_PM_PlayerTrace) (const float* start, const float* end, int traceFlags, int ignore_pe);
 	_PM_PlayerTrace ORIG_PM_PlayerTrace;
 	typedef void(__cdecl *_SV_AddLinksToPM) (char* node, float* origin);
@@ -314,6 +317,7 @@ protected:
 	struct Cmd_BXT_TAS_Split;
 	struct Cmd_BXT_TAS_New;
 	struct Cmd_BXT_CH_Set_Health;
+	struct Cmd_BXT_CH_Set_Angles;
 	struct Cmd_BXT_CH_Set_Armor;
 	struct Cmd_BXT_CH_Set_Origin;
 	struct Cmd_BXT_CH_Set_Origin_Offset;


### PR DESCRIPTION
Closes #147 

EDIT: Just noticed that there's some floating point error in setting the yaw, not sure why, but `bxt_ch_set_angles 10 10` ends up as:

![image](https://user-images.githubusercontent.com/5108747/118888640-35464880-b8fc-11eb-9d77-03c180cec9f5.png)

Any idea how to fix that?

`hudSetViewAngles` is:
```c++
void hudSetViewAngles(float *va)

{
  (*g_engdstAddrs.SetViewAngles)(&va);
  cl.viewangles[0] = (vec_t)*va;
  cl.viewangles[1] = (vec_t)va[1];
  cl.viewangles[2] = (vec_t)va[2];
  return;
}
```

Also, should the cheat also include the roll as an argument, seeing as it's a cheat anyway (and roll is sometimes set - e.g. when player dies and deathcam starts)? What do you think, @SmileyAG?