### PR TITLE
[Linux] Fix bxt_timer_autostop for games that stop based on a multi_manager 

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1367,7 +1367,7 @@ HOOK_DEF_2(ServerDLL, void, __fastcall, CMultiManager__ManagerThink, void*, this
 
 HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*, pActivator, void*, pCaller, int, useType, float, value)
 {
-	if(ppGlobals && targetName != NULL) {
+	if(ppGlobals && targetName != NULL && pCaller) {
 		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(pCaller) + 4);
 		if(pev && pev->targetname)
 		{
@@ -1379,8 +1379,7 @@ HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*
 				if (ClientDLL::GetInstance().pEngfuncs)
 					gameDir = ClientDLL::GetInstance().pEngfuncs->pfnGetGameDirectory();
 				if (!std::strcmp(targetname, "roll_the_credits")
-					|| !std::strcmp(targetName, "youwinmulti2")
-					|| !std::strcmp(targetname, "sink2")
+					|| !std::strcmp(targetName, "youwinmulti")
 					|| !std::strcmp(targetname, "previctory_mm")
 					|| !std::strcmp(targetname, "stairscene_mngr")
 					|| !std::strcmp(targetname, "boot_radio_seq")
@@ -1407,7 +1406,7 @@ HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*
 		}
 	}
 
-	ORIG_FireTargets_Linux(targetName, pActivator, pCaller, useType, value);
+	return ORIG_FireTargets_Linux(targetName, pActivator, pCaller, useType, value);
 }
 
 void ServerDLL::GetTriggerColor(const char *classname, bool inactive, bool additive, float &r, float &g, float &b, float &a)

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1347,7 +1347,6 @@ HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*
 		{
 			const char *targetname = (*ppGlobals)->pStringBase + pev->targetname;
 			const char *classname = (*ppGlobals)->pStringBase + pev->classname;
-			const char *gameDir = "";
 			// We first need to check if the pCaller is a multi_manager since FireTargets can be called by anyone
 			if (!std::strcmp(classname, "multi_manager")) {
 				DoMultiManagerAutoStop(targetname);

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1332,13 +1332,7 @@ HOOK_DEF_2(ServerDLL, void, __fastcall, CMultiManager__ManagerThink, void*, this
 		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4);
 		if (pev && pev->targetname) {
 			const char *targetname = (*ppGlobals)->pStringBase + pev->targetname;
-			if(IsMultiManagerAutoStopTargetName(targetname)) {
-				if (CVars::bxt_timer_autostop.GetBool())
-					CustomHud::SetCountingTime(false);
-				Interprocess::WriteGameEnd(CustomHud::GetTime());
-				CustomHud::SaveTimeToDemo();
-				RuntimeData::Add(RuntimeData::GameEndMarker {});
-			}
+			DoMultiManagerAutoStop(targetname);
 		}
 	}
 
@@ -1356,13 +1350,7 @@ HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*
 			const char *gameDir = "";
 			// We first need to check if the pCaller is a multi_manager since FireTargets can be called by anyone
 			if (!std::strcmp(classname, "multi_manager")) {
-				if(IsMultiManagerAutoStopTargetName(targetname)) {
-					if (CVars::bxt_timer_autostop.GetBool())
-						CustomHud::SetCountingTime(false);
-					Interprocess::WriteGameEnd(CustomHud::GetTime());
-					CustomHud::SaveTimeToDemo();
-					RuntimeData::Add(RuntimeData::GameEndMarker{});
-				}
+				DoMultiManagerAutoStop(targetname);
 			}
 		}
 	}
@@ -1370,30 +1358,35 @@ HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*
 	return ORIG_FireTargets_Linux(targetName, pActivator, pCaller, useType, value);
 }
 
-bool ServerDLL::IsMultiManagerAutoStopTargetName(const char *targetname)
+void ServerDLL::DoMultiManagerAutoStop(const char *targetname)
 {
 	const char *gameDir = "";
 	if (ClientDLL::GetInstance().pEngfuncs)
 		gameDir = ClientDLL::GetInstance().pEngfuncs->pfnGetGameDirectory();
 
-	return (!std::strcmp(targetname, "roll_the_credits")
-	    || !std::strcmp(targetname, "youwinmulti")
-	    || !std::strcmp(targetname, "previctory_mm")
-	    || !std::strcmp(targetname, "stairscene_mngr")
-	    || !std::strcmp(targetname, "boot_radio_seq")
-	    || !std::strcmp(targetname, "BLOOOM") // CSCZDS
-	    || (!std::strcmp(targetname, "telmm") && !std::strcmp(gameDir, "biglolly")) // Big Lolly
-	    || (!std::strcmp(targetname, "mm_player_camera1") && !std::strcmp(gameDir, "htc")) // HTC
-	    || (!std::strcmp(targetname, "multimanager_1") && !std::strcmp(gameDir, "construction")) // Construction
-	    || (!std::strcmp(targetname, "the_endgame_mm") && !std::strcmp(gameDir, "gloom")) // The Gloom
-	    || (!std::strcmp(targetname, "endbox_mm0") && !std::strcmp(gameDir, "echoes")) // Echoes
-	    || (!std::strcmp(targetname, "sendmm") && !std::strcmp(gameDir, "MINIMICUS"))  // Minimicus
-	    || (!std::strcmp(targetname, "kill2") && !std::strcmp(gameDir, "before")) // Before
-	    || (!std::strcmp(targetname, "tele_in") && !std::strcmp(gameDir, "plague")) // Plague
-	    || (!std::strcmp(targetname, "exit_seq") && !std::strcmp(gameDir, "timeline2")) // Timeline 2
-	    || (!std::strcmp(targetname, "spawn_garg_sci_mm") && !std::strcmp(gameDir, "SteamLink")) // Uplink
-	    || (!std::strcmp(targetname, "medicosprey") && !std::strcmp(gameDir, "visitors"))); // Visitors
-
+	if(!std::strcmp(targetname, "roll_the_credits")
+		|| !std::strcmp(targetname, "youwinmulti")
+		|| !std::strcmp(targetname, "previctory_mm")
+		|| !std::strcmp(targetname, "stairscene_mngr")
+		|| !std::strcmp(targetname, "boot_radio_seq")
+		|| !std::strcmp(targetname, "BLOOOM") // CSCZDS
+		|| (!std::strcmp(targetname, "telmm") && !std::strcmp(gameDir, "biglolly")) // Big Lolly
+		|| (!std::strcmp(targetname, "mm_player_camera1") && !std::strcmp(gameDir, "htc")) // HTC
+		|| (!std::strcmp(targetname, "multimanager_1") && !std::strcmp(gameDir, "construction")) // Construction
+		|| (!std::strcmp(targetname, "the_endgame_mm") && !std::strcmp(gameDir, "gloom")) // The Gloom
+		|| (!std::strcmp(targetname, "endbox_mm0") && !std::strcmp(gameDir, "echoes")) // Echoes
+		|| (!std::strcmp(targetname, "sendmm") && !std::strcmp(gameDir, "MINIMICUS"))  // Minimicus
+		|| (!std::strcmp(targetname, "kill2") && !std::strcmp(gameDir, "before")) // Before
+		|| (!std::strcmp(targetname, "tele_in") && !std::strcmp(gameDir, "plague")) // Plague
+		|| (!std::strcmp(targetname, "exit_seq") && !std::strcmp(gameDir, "timeline2")) // Timeline 2
+		|| (!std::strcmp(targetname, "spawn_garg_sci_mm") && !std::strcmp(gameDir, "SteamLink")) // Uplink
+		|| (!std::strcmp(targetname, "medicosprey") && !std::strcmp(gameDir, "visitors"))) { // Visitors
+		if (CVars::bxt_timer_autostop.GetBool())
+			CustomHud::SetCountingTime(false);
+		Interprocess::WriteGameEnd(CustomHud::GetTime());
+		CustomHud::SaveTimeToDemo();
+		RuntimeData::Add(RuntimeData::GameEndMarker{});
+	}
 }
 
 void ServerDLL::GetTriggerColor(const char *classname, bool inactive, bool additive, float &r, float &g, float &b, float &a)

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -31,10 +31,10 @@ extern "C" void __cdecl _ZN11COFGeneWorm10DyingThinkEv(void* thisptr)
 }
 
 // https://github.com/YaLTeR/BunnymodXT/issues/63
-// extern "C" void __cdecl _ZN13CMultiManager10ManagerUseEP11CBaseEntityS1_8USE_TYPEf(void* thisptr, void* pActivator, void* pCaller, int useType, float value)
-// {
-//         return ServerDLL::HOOKED_CMultiManager__ManagerUse_Linux(thisptr, pActivator, pCaller, useType, value);
-// }
+extern "C" void __cdecl _Z11FireTargetsPKcP11CBaseEntityS2_8USE_TYPEf(char* targetName, void* pActivator, void* pCaller, int useType, float value)
+{
+     return ServerDLL::HOOKED_FireTargets_Linux(targetName, pActivator, pCaller, useType, value);
+}
 
 extern "C" int __cdecl _Z13AddToFullPackP14entity_state_siP7edict_sS2_iiPh(struct entity_state_s* state, int e, edict_t* ent, edict_t* host, int hostflags, int player, unsigned char* pSet)
 {
@@ -158,7 +158,7 @@ void ServerDLL::Clear()
 	ORIG_CApache__DyingThink = nullptr;
 	ORIG_CBaseDoor__DoorGoUp = nullptr;
 	ORIG_CMultiManager__ManagerThink = nullptr;
-	ORIG_CMultiManager__ManagerUse_Linux = nullptr;
+	ORIG_FireTargets_Linux = nullptr;
 	ORIG_AddToFullPack = nullptr;
 	ORIG_CTriggerVolume__Spawn = nullptr;
 	ORIG_CTriggerVolume__Spawn_Linux = nullptr;
@@ -709,12 +709,12 @@ void ServerDLL::FindStuff()
 	if (ORIG_CMultiManager__ManagerThink) {
 		EngineDevMsg("[server dll] Found CMultiManager::ManagerThink at %p.\n", ORIG_CMultiManager__ManagerThink);
 	} else {
-		// https://github.com/YaLTeR/BunnymodXT/issues/63
-		// ORIG_CMultiManager__ManagerUse_Linux = reinterpret_cast<_CMultiManager__ManagerUse_Linux>(MemUtils::GetSymbolAddress(m_Handle, "_ZN13CMultiManager10ManagerUseEP11CBaseEntityS1_8USE_TYPEf"));
-		if (ORIG_CMultiManager__ManagerUse_Linux)
-			EngineDevMsg("[server dll] Found CMultiManager::ManagerUse [Linux] at %p.\n", ORIG_CMultiManager__ManagerUse_Linux);
+		// https://github.com/YaLTeR/BunnymodXT/issues/63 <- because of this issue FireTargets is hooked on Linux instead, which is what MM::Think calls anyway
+		ORIG_FireTargets_Linux = reinterpret_cast<_FireTargets_Linux>(MemUtils::GetSymbolAddress(m_Handle, "_Z11FireTargetsPKcP11CBaseEntityS2_8USE_TYPEf"));
+		if (ORIG_FireTargets_Linux)
+			EngineDevMsg("[server dll] Found FireTargets_Linux [Linux] at %p.\n", ORIG_FireTargets_Linux);
 		else {
-			EngineDevWarning("[server dll] Could not find CMultiManager::ManagerThink or CMultiManager::ManagerUse.\n");
+			EngineDevWarning("[server dll] Could not find FireTargets_Linux or CMultiManager::ManagerUse.\n");
 			EngineWarning("Blue Shift and Gunman Chronicles automatic timer stopping is not available.\n");
 		}
 	}
@@ -1365,29 +1365,49 @@ HOOK_DEF_2(ServerDLL, void, __fastcall, CMultiManager__ManagerThink, void*, this
 	return ORIG_CMultiManager__ManagerThink(thisptr, edx);
 }
 
-HOOK_DEF_5(ServerDLL, void, __cdecl, CMultiManager__ManagerUse_Linux, void*, thisptr, void*, pActivator, void*, pCaller, int, useType, float, value)
+HOOK_DEF_5(ServerDLL, void, __cdecl, FireTargets_Linux, char*, targetName, void*, pActivator, void*, pCaller, int, useType, float, value)
 {
-	if (ppGlobals && pCaller) {
-		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4);
-		if (pev && pev->targetname) {
+	if(ppGlobals && targetName != NULL) {
+		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(pCaller) + 4);
+		if(pev && pev->targetname)
+		{
 			const char *targetname = (*ppGlobals)->pStringBase + pev->targetname;
-			if (!std::strcmp(targetname, "roll_the_credits") || !std::strcmp(targetname, "youwinmulti")) {
-				entvars_t *callerPev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(pCaller) + 4);
-				if (callerPev && callerPev->targetname) {
-					const char *callerTargetname = (*ppGlobals)->pStringBase + callerPev->targetname;
-					if (!std::strcmp(callerTargetname, "mgr_take_over") || !std::strcmp(callerTargetname, "endbot")) {
-						if (CVars::bxt_timer_autostop.GetBool())
-							CustomHud::SetCountingTime(false);
-						Interprocess::WriteGameEnd(CustomHud::GetTime());
-						CustomHud::SaveTimeToDemo();
-						RuntimeData::Add(RuntimeData::GameEndMarker {});
-					}
+			const char *classname = (*ppGlobals)->pStringBase + pev->classname;
+			const char *gameDir = "";
+			// We first need to check if the pCaller is a multi_manager since FireTargets can be called by anyone
+			if (!std::strcmp(classname, "multi_manager")) {
+				if (ClientDLL::GetInstance().pEngfuncs)
+					gameDir = ClientDLL::GetInstance().pEngfuncs->pfnGetGameDirectory();
+				if (!std::strcmp(targetname, "roll_the_credits")
+					|| !std::strcmp(targetName, "youwinmulti2")
+					|| !std::strcmp(targetname, "sink2")
+					|| !std::strcmp(targetname, "previctory_mm")
+					|| !std::strcmp(targetname, "stairscene_mngr")
+					|| !std::strcmp(targetname, "boot_radio_seq")
+					|| !std::strcmp(targetname, "BLOOOM") // CSCZDS
+					|| (!std::strcmp(targetname, "telmm") && !std::strcmp(gameDir, "biglolly")) // Big Lolly
+					|| (!std::strcmp(targetname, "mm_player_camera1") && !std::strcmp(gameDir, "htc")) // HTC
+					|| (!std::strcmp(targetname, "multimanager_1") &&
+						!std::strcmp(gameDir, "construction")) // Construction
+					|| (!std::strcmp(targetname, "the_endgame_mm") && !std::strcmp(gameDir, "gloom")) // The Gloom
+					|| (!std::strcmp(targetname, "endbox_mm0") && !std::strcmp(gameDir, "echoes")) // Echoes
+					|| (!std::strcmp(targetname, "sendmm") && !std::strcmp(gameDir, "MINIMICUS"))  // Minimicus
+					|| (!std::strcmp(targetname, "kill2") && !std::strcmp(gameDir, "before")) // Before
+					|| (!std::strcmp(targetname, "tele_in") && !std::strcmp(gameDir, "plague")) // Plague
+					|| (!std::strcmp(targetname, "exit_seq") && !std::strcmp(gameDir, "timeline2")) // Timeline 2
+					|| (!std::strcmp(targetname, "spawn_garg_sci_mm") && !std::strcmp(gameDir, "SteamLink")) // Uplink
+					|| (!std::strcmp(targetname, "medicosprey") && !std::strcmp(gameDir, "visitors"))) { // Visitors
+					if (CVars::bxt_timer_autostop.GetBool())
+						CustomHud::SetCountingTime(false);
+					Interprocess::WriteGameEnd(CustomHud::GetTime());
+					CustomHud::SaveTimeToDemo();
+					RuntimeData::Add(RuntimeData::GameEndMarker{});
 				}
 			}
 		}
 	}
 
-	return ORIG_CMultiManager__ManagerUse_Linux(thisptr, pActivator, pCaller, useType, value);
+	ORIG_FireTargets_Linux(targetName, pActivator, pCaller, useType, value);
 }
 
 void ServerDLL::GetTriggerColor(const char *classname, bool inactive, bool additive, float &r, float &g, float &b, float &a)

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -60,7 +60,7 @@ public:
 		return (*ppGlobals)->pStringBase + string;
 	}
 
-	static bool IsMultiManagerAutoStopTargetName(const char *classname);
+	static void DoMultiManagerAutoStop(const char *classname);
 
 	static void GetTriggerColor(const char *classname, bool inactive, bool additive, float &r, float &g, float &b, float &a);
 

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -7,7 +7,6 @@
 
 class ServerDLL : public IHookableDirFilter
 {
-
 	HOOK_DECL(void, __cdecl, PM_Jump)
 	HOOK_DECL(void, __cdecl, PM_PreventMegaBunnyJumping)
 	HOOK_DECL(void, __cdecl, PM_PlayerMove, qboolean server)
@@ -60,6 +59,8 @@ public:
 		assert(ppGlobals);
 		return (*ppGlobals)->pStringBase + string;
 	}
+
+	static bool IsMultiManagerAutoStopTargetName(const char *classname);
 
 	static void GetTriggerColor(const char *classname, bool inactive, bool additive, float &r, float &g, float &b, float &a);
 

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -7,6 +7,7 @@
 
 class ServerDLL : public IHookableDirFilter
 {
+
 	HOOK_DECL(void, __cdecl, PM_Jump)
 	HOOK_DECL(void, __cdecl, PM_PreventMegaBunnyJumping)
 	HOOK_DECL(void, __cdecl, PM_PlayerMove, qboolean server)
@@ -24,7 +25,7 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __fastcall, CApache__DyingThink, void* thisptr)
 	HOOK_DECL(void, __fastcall, CBaseDoor__DoorGoUp, void* thisptr)
 	HOOK_DECL(void, __fastcall, CMultiManager__ManagerThink, void* thisptr, int edx)
-	HOOK_DECL(void, __cdecl, CMultiManager__ManagerUse_Linux, void* thisptr, void* pActivator, void* pCaller, int useType, float value)
+	HOOK_DECL(void, __cdecl, FireTargets_Linux, char* targetName, void* pActivator, void* pCaller, int useType, float value)
 	HOOK_DECL(int, __cdecl, AddToFullPack, struct entity_state_s* state, int e, edict_t* ent, edict_t* host, int hostflags, int player, unsigned char* pSet)
 	HOOK_DECL(void, __fastcall, CTriggerVolume__Spawn, void* thisptr)
 	HOOK_DECL(void, __cdecl, CTriggerVolume__Spawn_Linux, void* thisptr)


### PR DESCRIPTION
Fixes #63 (works around it).

Like we've discussed with @YaLTeR on the SourceRuns Discord:
Fix bxt_timer_autostop for games like Blue-Shift, GMC, etc. that end on a multi_manager being fired (`CMultiManager__ManagerThink` on Windows). On Linux instead use a `FireTargets` hook, which is what is called in `MultiManager_ManagerThink()` anyway:

```c++
void CMultiManager :: ManagerThink ( void )
{
	float	time;

	time = gpGlobals->time - m_startTime;
	while ( m_index < m_cTargets && m_flTargetDelay[ m_index ] <= time )
	{
		FireTargets( STRING( m_iTargetName[ m_index ] ), m_hActivator, this, USE_TOGGLE, 0 );
		m_index++;
	}
// [...] etc.
}
```


All the remaining code in this PR for the autostopping is just a direct copy-paste from the Win `ManagerThink`, except that in `FireTargets` there's also a check if the classname of the pCaller is actually a `multi_manager` since `FireTargets` is called by many other entities.

**Tested in Blue Shift:** https://user-images.githubusercontent.com/5108747/121822559-fc518780-cc9f-11eb-9f89-7278f775a356.mp4




