### PR TITLE
Added bxt_disable_bshift_outro_save

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -43,6 +43,7 @@ namespace CVars
 	CVarWrapper bxt_show_triggers_legacy("bxt_show_triggers_legacy", "0");
 	CVarWrapper bxt_show_pickup_bbox("bxt_show_pickup_bbox", "0");
 	CVarWrapper bxt_disable_autosave("bxt_disable_autosave", "0");
+	CVarWrapper bxt_disable_bshift_outro_save("bxt_disable_bshift_outro_save", "0");
 	CVarWrapper bxt_disable_changelevel("bxt_disable_changelevel", "0");
 
 	// Clientside CVars
@@ -152,6 +153,7 @@ namespace CVars
 		&bxt_show_displacer_earth_targets,
 		&bxt_show_pickup_bbox,
 		&bxt_disable_autosave,
+		&bxt_disable_bshift_outro_save,
 		&bxt_disable_changelevel,
 		&bxt_show_custom_triggers,
 		&bxt_wallhack,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -150,6 +150,7 @@ namespace CVars
 	extern CVarWrapper bxt_show_triggers_legacy;
 	extern CVarWrapper bxt_show_pickup_bbox;
 	extern CVarWrapper bxt_disable_autosave;
+	extern CVarWrapper bxt_disable_bshift_outro_save;
 	extern CVarWrapper bxt_disable_changelevel;
 
 	// Clientside CVars

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -34,6 +34,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(int, __cdecl, SV_SpawnServer, int bIsDemo, char* server, char* startspot)
 	HOOK_DECL(void, __cdecl, CL_Stop_f)
 	HOOK_DECL(void, __cdecl, Host_Loadgame_f)
+	HOOK_DECL(void, __cdecl, Host_Savegame_f)
 	HOOK_DECL(void, __cdecl, Host_Reload_f)
 	HOOK_DECL(void, __cdecl, VGuiWrap2_ConDPrintf, const char* msg)
 	HOOK_DECL(void, __cdecl, VGuiWrap2_ConPrintf, const char* msg)


### PR DESCRIPTION
Quality of life feature for not accidentally crashing your game at the end of a run by saving the game.
Maybe needs some more checks that I don't know about... dunno + maybe find a way to only register the cvar (and maybe also only hook) when the game is bshift? 
Also missing Win patterns (like always).

https://github.com/ValveSoftware/halflife/issues/1014
