### PR TITLE
Added bxt_disable_skybox

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -14,6 +14,7 @@ namespace CVars
 	CVarWrapper bxt_autopause("bxt_autopause", "0");
 	CVarWrapper bxt_interprocess_enable("bxt_interprocess_enable", "0");
 	CVarWrapper bxt_fade_remove("bxt_fade_remove", "0");
+	CVarWrapper bxt_disable_skybox("bxt_disable_skybox", "0");
 	CVarWrapper bxt_stop_demo_on_changelevel("bxt_stop_demo_on_changelevel", "0");
 	CVarWrapper bxt_tas_editor_simulate_for_ms("bxt_tas_editor_simulate_for_ms", "40");
 	CVarWrapper bxt_tas_norefresh_until_last_frames("bxt_tas_norefresh_until_last_frames", "0");
@@ -124,6 +125,7 @@ namespace CVars
 		&bxt_autopause,
 		&bxt_interprocess_enable,
 		&bxt_fade_remove,
+		&bxt_disable_skybox,
 		&bxt_stop_demo_on_changelevel,
 		&bxt_tas_editor_simulate_for_ms,
 		&bxt_tas_norefresh_until_last_frames,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -121,6 +121,7 @@ namespace CVars
 	extern CVarWrapper bxt_autopause;
 	extern CVarWrapper bxt_interprocess_enable;
 	extern CVarWrapper bxt_fade_remove;
+	extern CVarWrapper bxt_disable_skybox;
 	extern CVarWrapper bxt_stop_demo_on_changelevel;
 	extern CVarWrapper bxt_tas_editor_simulate_for_ms;
 	extern CVarWrapper bxt_tas_norefresh_until_last_frames;

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -57,6 +57,11 @@ extern "C" int __cdecl V_FadeAlpha()
 	return HwDLL::HOOKED_V_FadeAlpha();
 }
 
+extern "C" void __cdecl R_DrawSkyBox()
+{
+	return HwDLL::HOOKED_R_DrawSkyBox();
+}
+
 extern "C" void __cdecl SCR_UpdateScreen()
 {
 	return HwDLL::HOOKED_SCR_UpdateScreen();
@@ -225,6 +230,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			MemUtils::MarkAsExecutable(ORIG_SCR_BeginLoadingPlaque);
 			MemUtils::MarkAsExecutable(ORIG_Host_FilterTime);
 			MemUtils::MarkAsExecutable(ORIG_V_FadeAlpha);
+			MemUtils::MarkAsExecutable(ORIG_R_DrawSkyBox);
 			MemUtils::MarkAsExecutable(ORIG_SCR_UpdateScreen);
 			MemUtils::MarkAsExecutable(ORIG_SV_SpawnServer);
 			MemUtils::MarkAsExecutable(ORIG_SV_Frame);
@@ -257,6 +263,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_SCR_BeginLoadingPlaque, HOOKED_SCR_BeginLoadingPlaque,
 			ORIG_Host_FilterTime, HOOKED_Host_FilterTime,
 			ORIG_V_FadeAlpha, HOOKED_V_FadeAlpha,
+			ORIG_R_DrawSkyBox, HOOKED_R_DrawSkyBox,
 			ORIG_SCR_UpdateScreen, HOOKED_SCR_UpdateScreen,
 			ORIG_SV_SpawnServer, HOOKED_SV_SpawnServer,
 			ORIG_SV_Frame, HOOKED_SV_Frame,
@@ -295,6 +302,7 @@ void HwDLL::Unhook()
 			ORIG_SCR_BeginLoadingPlaque,
 			ORIG_Host_FilterTime,
 			ORIG_V_FadeAlpha,
+			ORIG_R_DrawSkyBox,
 			ORIG_SCR_UpdateScreen,
 			ORIG_SV_SpawnServer,
 			ORIG_SV_Frame,
@@ -332,6 +340,7 @@ void HwDLL::Clear()
 	ORIG_SCR_BeginLoadingPlaque = nullptr;
 	ORIG_Host_FilterTime = nullptr;
 	ORIG_V_FadeAlpha = nullptr;
+	ORIG_R_DrawSkyBox = nullptr;
 	ORIG_SCR_UpdateScreen = nullptr;
 	ORIG_SV_Frame = nullptr;
 	ORIG_SV_SpawnServer = nullptr;
@@ -651,6 +660,12 @@ void HwDLL::FindStuff()
 		else
 			EngineDevWarning("[hw dll] Could not find V_FadeAlpha.\n");
 
+		ORIG_R_DrawSkyBox = reinterpret_cast<_R_DrawSkyBox>(MemUtils::GetSymbolAddress(m_Handle, "R_DrawSkyBox"));
+		if (ORIG_R_DrawSkyBox)
+			EngineDevMsg("[hw dll] Found R_DrawSkyBox at %p.\n", ORIG_R_DrawSkyBox);
+		else
+			EngineDevWarning("[hw dll] Could not find R_DrawSkyBox.\n");
+
 		ORIG_SCR_UpdateScreen = reinterpret_cast<_SCR_UpdateScreen>(MemUtils::GetSymbolAddress(m_Handle, "SCR_UpdateScreen"));
 		if (ORIG_SCR_UpdateScreen)
 			EngineDevMsg("[hw dll] Found SCR_UpdateScreen at %p.\n", ORIG_SCR_UpdateScreen);
@@ -734,6 +749,7 @@ void HwDLL::FindStuff()
 		DEF_FUTURE(PM_PlayerTrace)
 		DEF_FUTURE(Host_FilterTime)
 		DEF_FUTURE(V_FadeAlpha)
+		DEF_FUTURE(R_DrawSkyBox)
 		DEF_FUTURE(SCR_UpdateScreen)
 		DEF_FUTURE(PF_GetPhysicsKeyValue)
 		DEF_FUTURE(build_number)
@@ -1279,6 +1295,7 @@ void HwDLL::FindStuff()
 			}
 		GET_FUTURE(Host_FilterTime);
 		GET_FUTURE(V_FadeAlpha);
+		GET_FUTURE(R_DrawSkyBox)
 		GET_FUTURE(SV_Frame);
 		GET_FUTURE(VGuiWrap2_ConDPrintf);
 		GET_FUTURE(VGuiWrap2_ConPrintf);
@@ -2811,6 +2828,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_bhopcap);
 	RegisterCVar(CVars::bxt_interprocess_enable);
 	RegisterCVar(CVars::bxt_fade_remove);
+	RegisterCVar(CVars::bxt_disable_skybox);
 	RegisterCVar(CVars::bxt_stop_demo_on_changelevel);
 	RegisterCVar(CVars::bxt_tas_editor_simulate_for_ms);
 	RegisterCVar(CVars::bxt_tas_norefresh_until_last_frames);
@@ -4283,6 +4301,14 @@ HOOK_DEF_0(HwDLL, int, __cdecl, V_FadeAlpha)
 		return 0;
 	else
 		return ORIG_V_FadeAlpha();
+}
+
+HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawSkyBox)
+{
+	if (CVars::bxt_disable_skybox.GetBool())
+		return;
+	else
+		return ORIG_R_DrawSkyBox();
 }
 
 HOOK_DEF_3(HwDLL, int, __cdecl, SV_SpawnServer, int, bIsDemo, char*, server, char*, startspot)

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4528,7 +4528,7 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_Clear)
 {
 	// This is needed or everything will look washed out or with unintended
 	// motion blur.
-	if (CVars::sv_cheats.GetBool() && CVars::bxt_wallhack.GetBool()) {
+	if (CVars::sv_cheats.GetBool() && CVars::bxt_wallhack.GetBool() || CVars::bxt_disable_skybox.GetBool()) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3666,7 +3666,7 @@ void HwDLL::FindCVarsIfNeeded()
 HLStrafe::MovementVars HwDLL::GetMovementVars()
 {
 	auto vars = HLStrafe::MovementVars();
-	
+
 	FindCVarsIfNeeded();
 	vars.Frametime = GetFrameTime();
 	vars.Maxvelocity = CVars::sv_maxvelocity.GetFloat();
@@ -4307,10 +4307,10 @@ HOOK_DEF_0(HwDLL, int, __cdecl, V_FadeAlpha)
 
 HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawSkyBox)
 {
-	if (CVars::bxt_disable_skybox.GetBool())
+	if (CVars::sv_cheats.GetBool() && CVars::bxt_disable_skybox.GetBool())
 		return;
-	else
-		return ORIG_R_DrawSkyBox();
+
+	ORIG_R_DrawSkyBox();
 }
 
 HOOK_DEF_3(HwDLL, int, __cdecl, SV_SpawnServer, int, bIsDemo, char*, server, char*, startspot)
@@ -4530,7 +4530,7 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_Clear)
 {
 	// This is needed or everything will look washed out or with unintended
 	// motion blur.
-	if (CVars::sv_cheats.GetBool() && CVars::bxt_wallhack.GetBool() || CVars::bxt_disable_skybox.GetBool()) {
+	if (CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_disable_skybox.GetBool())) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -661,10 +661,12 @@ void HwDLL::FindStuff()
 			EngineDevWarning("[hw dll] Could not find V_FadeAlpha.\n");
 
 		ORIG_R_DrawSkyBox = reinterpret_cast<_R_DrawSkyBox>(MemUtils::GetSymbolAddress(m_Handle, "R_DrawSkyBox"));
-		if (ORIG_R_DrawSkyBox)
+		if (ORIG_R_DrawSkyBox) {
 			EngineDevMsg("[hw dll] Found R_DrawSkyBox at %p.\n", ORIG_R_DrawSkyBox);
-		else
+		} else {
 			EngineDevWarning("[hw dll] Could not find R_DrawSkyBox.\n");
+			EngineWarning("bxt_disable_skybox is not available.\n");
+		}
 
 		ORIG_SCR_UpdateScreen = reinterpret_cast<_SCR_UpdateScreen>(MemUtils::GetSymbolAddress(m_Handle, "SCR_UpdateScreen"));
 		if (ORIG_SCR_UpdateScreen)

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -29,6 +29,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, SCR_BeginLoadingPlaque)
 	HOOK_DECL(int, __cdecl, Host_FilterTime, float timePassed)
 	HOOK_DECL(int, __cdecl, V_FadeAlpha)
+	HOOK_DECL(void, __cdecl, R_DrawSkyBox)
 	HOOK_DECL(void, __cdecl, SCR_UpdateScreen)
 	HOOK_DECL(void, __cdecl, SV_Frame)
 	HOOK_DECL(int, __cdecl, SV_SpawnServer, int bIsDemo, char* server, char* startspot)

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -340,6 +340,11 @@ namespace patterns
 			"HL-NGHL",
 			"B8 28 54 01 00 E8 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 53 8B 9C 24 30 54 01 00"
 		);
+
+		PATTERNS(R_DrawSkyBox,
+			"HL-SteamPipe",
+			"55 8B EC 83 EC 1C A1 ?? ?? ?? ?? 53 56 BB 00 00 80 3F 57 C7 45 F8 00 00 00 00 85 C0"
+		);
 	}
 
 	namespace server

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -343,7 +343,11 @@ namespace patterns
 
 		PATTERNS(R_DrawSkyBox,
 			"HL-SteamPipe",
-			"55 8B EC 83 EC 1C A1 ?? ?? ?? ?? 53 56 BB 00 00 80 3F 57 C7 45 F8 00 00 00 00 85 C0"
+			"55 8B EC 83 EC 1C A1 ?? ?? ?? ?? 53 56",
+			"HL-4554",
+			"83 EC 1C A1 ?? ?? ?? ?? 53 55",
+			"HL-WON-1712",
+			"83 EC 0C 53 55 56 57 E8 ?? ?? ?? ?? 33 FF"
 		);
 	}
 


### PR DESCRIPTION
Note: 

The main reason why I made this cvar is to solve #170 issue in an easy and dumb way, but if someone fixes it by modifying the wallhack or skybox-engine code, then I will close the PR probably (since I do not see any other useful use-cases, which require disabling the skybox in the game).