### PR TITLE
[Linux] Fix mouse for 2013 SDK mods that don't fix rawinput themselves

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -178,6 +178,11 @@ extern "C" void __cdecl SV_SetMoveVars()
 {
 	HwDLL::HOOKED_SV_SetMoveVars();
 }
+
+extern "C" qboolean __cdecl BIsValveGame()
+{
+	return true;
+}
 #endif
 
 void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept)


### PR DESCRIPTION
Fixes the annoying bug where mouse movement doesn't go past certain points in horizontal directions unless the devs of the mod specifically fix it in the 2013 SDK code. Tested on two SDK2013 linux-native mods:  **_Half-Life Glitchless_** & **_Thicc-Life: A fat adventure_** (Thicc-Life, specifically, uses the original Valve's HL Steam`hl/dlls/hl.so`), works fine on both.

Couldn't really tell if this breaks existing mods, that already fix raw input themselves - I personally tried it on **_Solo Mission Decay Demo 1_** & **_Open AG_**  and it felt the same as when BXT (with this commit) is **not** injected.
 
If someone could do some further testing to see if they feel any difference, it'd be appreciated... or we could just make it this a cvar just to be sure it doesn't break mods with fixed rawinput (like Solo Mission, OpenAG)?



**Before:**
https://user-images.githubusercontent.com/5108747/131410795-21ecd644-976e-46ec-a4fa-d9ccb0f7296c.mp4

**After:**
https://user-images.githubusercontent.com/5108747/131410801-1f0628f2-9333-4b72-94a3-fc31dd9ba339.mp4
(Sry for low bitrate in the demonstration, I've accidentally 1080p'd when I usually 720p)
