### PR TITLE
Added hornet crash prevention

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1838,14 +1838,9 @@ HOOK_DEF_4(ServerDLL, void, __fastcall, CPushable__Move, void*, thisptr, int, ed
 
 void ServerDLL::DoWouldCrashMessage()
 {
-	// We send a user message from the ServerDLL so that we have the notice in the demo.
-	int gmsgTextMsg = pEngfuncs->pfnRegUserMsg( "TextMsg", -1 );
-
-	pEngfuncs->pfnMessageBegin(MSG_ALL, gmsgTextMsg, NULL, NULL);
-	pEngfuncs->pfnWriteByte(HUD_PRINTTALK );
-	pEngfuncs->pfnWriteString("The game would have crashed. BXT prevented the crash and the timer was stopped. This run is no longer valid.\n");
-	pEngfuncs->pfnMessageEnd();
-
+	char command[] = "say The game would have crashed. BXT prevented the crash and the timer was stopped. This run is no longer valid.\n";
+	// We send a say message from the ServerDLL so that we have the notice in the demo.
+	pEngfuncs->pfnServerCommand(command);
 	// Console
 	pEngfuncs->pfnServerPrint("[BXT] The game would have crashed. BXT prevented the crash and the timer was stopped. This run is no longer valid.\n");
 
@@ -1905,7 +1900,6 @@ HOOK_DEF_5(ServerDLL, int, __cdecl, CBasePlayer__TakeDamage_Linux, void*, thispt
 	{
 		return ORIG_CBasePlayer__TakeDamage_Linux(thisptr, pevInflictor, pevAttacker, flDamage, bitsDamageType);
 	}
-
 }
 
 HOOK_DEF_1(ServerDLL, void, __fastcall, CGraph__InitGraph, void*, thisptr)

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -33,6 +33,7 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __cdecl, ClientCommand, edict_t* pEntity)
 	HOOK_DECL(void, __fastcall, CPushable__Move, void* thisptr, int edx, void* pOther, int push)
 	HOOK_DECL(int, __fastcall, CBasePlayer__TakeDamage, void* thisptr, int edx, entvars_t* pevInflictor, entvars_t* pevAttacker, float flDamage, int bitsDamageType)
+	HOOK_DECL(int, __cdecl, CBasePlayer__TakeDamage_Linux, void* thisptr, entvars_t* pevInflictor, entvars_t* pevAttacker, float flDamage, int bitsDamageType)
 	HOOK_DECL(void, __fastcall, CGraph__InitGraph, void* thisptr)
 	HOOK_DECL(void, __cdecl, CGraph__InitGraph_Linux, void* thisptr)
 	HOOK_DECL(void, __fastcall, CBasePlayer__CheatImpulseCommands, void* thisptr, int edx, int iImpulse)
@@ -107,6 +108,8 @@ protected:
 	void RegisterCVarsAndCommands();
 	void LogPlayerMove(bool pre, uintptr_t pmove) const;
 	bool IsPlayerMovingPushable(const entvars_t *pevPushable, const entvars_t *pevToucher, int push) const;
+
+	void DoWouldCrashMessage();
 
 	void **ppmove;
 	ptrdiff_t offPlayerIndex;


### PR DESCRIPTION
Implements part of #64 

Prints crash message to "chat" and console from as a usermsg from serverDLL so that it's visible in the demo, doesn't stop demo playback. 

**Video:**
https://user-images.githubusercontent.com/5108747/132017938-b239f6a6-e351-49df-bbca-e258688e9e80.mp4

* Tested on Windows & Linux. 
* If you think registering a usermsg could be potentially bad, then hooking `UTIL_ClientPrintAll` from ServerDLL is an alternative, if that's preferred, I'll do that instead.
* I can add a ClientDLL hud thing as well, I just didn't wanna bother (KISS) because it requires fiddling with flTime in order for it to disappear eventually, but if it'd be preferred, I'll do it.


Save file by Smiley for Steam version: https://shitpost.fun/hornet.sav (sometimes it doesn't crash when you move out of the way or the hornet just doesn't hit you because RNG, like seen in the video)
BT:
```c++
#0  CBaseEntity::Instance (pev=0x0) at ../dlls/player.cpp:4901
#1  CBasePlayer::TakeDamage (this=0x9d815f0, pevInflictor=0xc862df04, pevAttacker=0x0, flDamage=4, bitsDamageType=2) at ../dlls/player.cpp:471
#2  0x8630daef in CHornet::DieTouch (this=0x9d61bc0, pOther=0x9d815f0) at ../dlls/hornet.cpp:410
#3  0xf4b35075 in SV_Impact (ptrace=0xffec0b60, e2=0xc861076c, e1=0xc862de84) at ../engine/sv_phys.c:195
#4  SV_Impact (e1=0xc862de84, e2=0xc861076c, ptrace=0xffec0b60) at ../engine/sv_phys.c:170
#5  0xf4b35ac2 in SV_PushEntity (ent=0xc862de84, push=0xffec0c80) at ../engine/sv_phys.c:545
#6  0xf4b3803a in SV_Physics_Toss (ent=0xc862de84) at ../engine/sv_phys.c:1578
#7  0xf4b396e8 in SV_Physics () at ../engine/sv_phys.c:2054
#8  0xf4b31236 in SV_Frame () at ../engine/sv_main.c:9355
#9  0xf4af07c6 in _Host_Frame (time=0.0216090735) at ../engine/host.c:1430
#10 0xf4af0c52 in Host_Frame (time=0.0216090735, iState=4, stateInfo=0xffec0e0c) at ../engine/host.c:1548
#11 0xf4b1db04 in CEngine::Frame (this=0xf4d37aa0 <g_Engine>) at ../engine/sys_engine.cpp:245
```