### PR TITLE
Added bxt_water_remove

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -15,6 +15,7 @@ namespace CVars
 	CVarWrapper bxt_interprocess_enable("bxt_interprocess_enable", "0");
 	CVarWrapper bxt_fade_remove("bxt_fade_remove", "0");
 	CVarWrapper bxt_skybox_remove("bxt_skybox_remove", "0");
+	CVarWrapper bxt_water_remove("bxt_water_remove", "0");
 	CVarWrapper bxt_stop_demo_on_changelevel("bxt_stop_demo_on_changelevel", "0");
 	CVarWrapper bxt_tas_editor_simulate_for_ms("bxt_tas_editor_simulate_for_ms", "40");
 	CVarWrapper bxt_tas_norefresh_until_last_frames("bxt_tas_norefresh_until_last_frames", "0");
@@ -144,6 +145,7 @@ namespace CVars
 		&bxt_interprocess_enable,
 		&bxt_fade_remove,
 		&bxt_skybox_remove,
+		&bxt_water_remove,
 		&bxt_stop_demo_on_changelevel,
 		&bxt_tas_editor_simulate_for_ms,
 		&bxt_tas_norefresh_until_last_frames,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -122,6 +122,7 @@ namespace CVars
 	extern CVarWrapper bxt_interprocess_enable;
 	extern CVarWrapper bxt_fade_remove;
 	extern CVarWrapper bxt_skybox_remove;
+	extern CVarWrapper bxt_water_remove;
 	extern CVarWrapper bxt_stop_demo_on_changelevel;
 	extern CVarWrapper bxt_tas_editor_simulate_for_ms;
 	extern CVarWrapper bxt_tas_norefresh_until_last_frames;

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -198,6 +198,11 @@ extern "C" qboolean __cdecl BIsValveGame()
 {
 	return true;
 }
+
+extern "C" void __cdecl EmitWaterPolys(msurface_t *fa, int direction)
+{
+	return HwDLL::HOOKED_EmitWaterPolys(fa, direction);
+}
 #endif
 
 void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept)
@@ -288,6 +293,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			MemUtils::MarkAsExecutable(ORIG_SV_SetMoveVars);
 			MemUtils::MarkAsExecutable(ORIG_R_StudioCalcAttachments);
 			MemUtils::MarkAsExecutable(ORIG_VectorTransform);
+			MemUtils::MarkAsExecutable(ORIG_EmitWaterPolys);
 		}
 
 		MemUtils::Intercept(moduleName,
@@ -326,7 +332,8 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_DispatchDirectUserMsg, HOOKED_DispatchDirectUserMsg,
 			ORIG_SV_SetMoveVars, HOOKED_SV_SetMoveVars,
 			ORIG_VectorTransform, HOOKED_VectorTransform,
-			ORIG_R_StudioCalcAttachments, HOOKED_R_StudioCalcAttachments);
+			ORIG_R_StudioCalcAttachments, HOOKED_R_StudioCalcAttachments,
+			ORIG_EmitWaterPolys, HOOKED_EmitWaterPolys);
 	}
 }
 
@@ -371,7 +378,8 @@ void HwDLL::Unhook()
 			ORIG_DispatchDirectUserMsg,
 			ORIG_SV_SetMoveVars,
 			ORIG_VectorTransform,
-			ORIG_R_StudioCalcAttachments);
+			ORIG_R_StudioCalcAttachments,
+			ORIG_EmitWaterPolys);
 	}
 
 	for (auto cvar : CVars::allCVars)
@@ -435,6 +443,7 @@ void HwDLL::Clear()
 	ORIG_studioapi_GetCurrentEntity = nullptr;
 	ORIG_R_StudioCalcAttachments = nullptr;
 	ORIG_VectorTransform = nullptr;
+	ORIG_EmitWaterPolys = nullptr;
 
 	registeredVarsAndCmds = false;
 	autojump = false;
@@ -851,6 +860,14 @@ void HwDLL::FindStuff()
 			EngineWarning("Demo crash fix in Counter-Strike: Condition Zero Deleted Scenes is not available.\n");
 		}
 
+		ORIG_EmitWaterPolys = reinterpret_cast<_EmitWaterPolys>(MemUtils::GetSymbolAddress(m_Handle, "EmitWaterPolys"));
+		if (ORIG_EmitWaterPolys) {
+			EngineDevMsg("[hw dll] Found EmitWaterPolys at %p.\n", ORIG_EmitWaterPolys);
+		} else {
+			EngineDevWarning("[hw dll] Could not find EmitWaterPolys.\n");
+			EngineWarning("bxt_water_remove has no effect.\n");
+		}
+
 		const auto CL_Move = reinterpret_cast<uintptr_t>(MemUtils::GetSymbolAddress(m_Handle, "CL_Move"));
 		if (CL_Move)
 		{
@@ -897,6 +914,7 @@ void HwDLL::FindStuff()
 		DEF_FUTURE(studioapi_GetCurrentEntity)
 		DEF_FUTURE(VGuiWrap_Paint)
 		DEF_FUTURE(DispatchDirectUserMsg)
+		DEF_FUTURE(EmitWaterPolys)
 		#undef DEF_FUTURE
 
 		bool oldEngine = (m_Name.find(L"hl.exe") != std::wstring::npos);
@@ -1480,6 +1498,7 @@ void HwDLL::FindStuff()
 		GET_FUTURE(VGuiWrap_Paint);
 		GET_FUTURE(DispatchDirectUserMsg);
 		GET_FUTURE(studioapi_GetCurrentEntity);
+		GET_FUTURE(EmitWaterPolys);
 
 		if (oldEngine) {
 			GET_FUTURE(LoadAndDecryptHwDLL);
@@ -3003,6 +3022,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_interprocess_enable);
 	RegisterCVar(CVars::bxt_fade_remove);
 	RegisterCVar(CVars::bxt_skybox_remove);
+	RegisterCVar(CVars::bxt_water_remove);
 	RegisterCVar(CVars::bxt_stop_demo_on_changelevel);
 	RegisterCVar(CVars::bxt_tas_editor_simulate_for_ms);
 	RegisterCVar(CVars::bxt_tas_norefresh_until_last_frames);
@@ -4732,7 +4752,7 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_Clear)
 {
 	// This is needed or everything will look washed out or with unintended
 	// motion blur.
-	if (CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool())) {
+	if (CVars::bxt_water_remove.GetBool() || CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool())) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}
@@ -4832,4 +4852,12 @@ HOOK_DEF_3(HwDLL, void, __cdecl, VectorTransform, float*, in1, float*, in2, floa
 		out[1] = vOrigin[1];
 		out[2] = vOrigin[2];
 	}
+}
+
+HOOK_DEF_2(HwDLL, void, __cdecl, EmitWaterPolys, msurface_t *, fa, int, direction)
+{
+	if (CVars::bxt_water_remove.GetBool())
+		return;
+
+	ORIG_EmitWaterPolys(fa, direction);
 }

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4752,7 +4752,7 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_Clear)
 {
 	// This is needed or everything will look washed out or with unintended
 	// motion blur.
-	if (CVars::bxt_water_remove.GetBool() || CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool())) {
+	if (CVars::bxt_water_remove.GetBool() || (CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool()))) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -52,6 +52,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, SV_SetMoveVars)
 	HOOK_DECL(void, __cdecl, VectorTransform, float *in1, float *in2, float *out)
 	HOOK_DECL(void, __cdecl, R_StudioCalcAttachments)
+	HOOK_DECL(void, __cdecl, EmitWaterPolys, msurface_t *fa, int direction)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -391,6 +391,13 @@ namespace patterns
 			"HL-SteamPipe",
 			"8B 0D ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? 04"
 		);
+
+		PATTERNS(EmitWaterPolys,
+			"HL-SteamPipe",
+			"55 8B EC 83 EC 20 56 8B 75 ?? 33 D2",
+			"HL-4554",
+			"83 EC 1C 33 D2 55 56 8B 74 24 28 57 8B 46 2C 8B 48 24 8B 41 44 33 C9 8A 50 0C 8A 48 0B 52 51 33 D2"
+		);
 	}
 
 	namespace server


### PR DESCRIPTION
Boosts framerate via disabling draw of water textures*

*Yes I know that water could be disabled via `r_drawentities 0`, although its not works with all types of water (e.g., `map c1a4`)

I decided to not add check for cheats on the cvar, since I use this for segmenting and I would not like to see mention of `sv_cheats 1` in the log of .dem 

UPD: Recommended to use in combination with `r_novis 1` to make water fully masked