### PR TITLE
Add cvars to disable viewmodel idle/equip sequences

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -25,6 +25,8 @@ namespace CVars
 	CVarWrapper bxt_disable_vgui("bxt_disable_vgui", "0");
 	CVarWrapper bxt_force_zmax("bxt_force_zmax", "0");
 	CVarWrapper bxt_viewmodel_fov("bxt_viewmodel_fov", "0");
+	CVarWrapper bxt_viewmodel_disable_idle("bxt_viewmodel_disable_idle", "0");
+	CVarWrapper bxt_viewmodel_disable_equip("bxt_viewmodel_disable_equip", "0");
 
 	CVarWrapper con_color;
 	CVarWrapper sv_cheats;
@@ -159,6 +161,8 @@ namespace CVars
 		&bxt_disable_vgui,
 		&bxt_force_zmax,
 		&bxt_viewmodel_fov,
+		&bxt_viewmodel_disable_idle,
+		&bxt_viewmodel_disable_equip,
 		&con_color,
 		&sv_cheats,
 		&sv_maxvelocity,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -138,6 +138,8 @@ namespace CVars
 	extern CVarWrapper bxt_disable_vgui;
 	extern CVarWrapper bxt_force_zmax;
 	extern CVarWrapper bxt_viewmodel_fov;
+	extern CVarWrapper bxt_viewmodel_disable_idle;
+	extern CVarWrapper bxt_viewmodel_disable_equip;
 
 	extern CVarWrapper con_color;
 	extern CVarWrapper sv_cheats;

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -27,6 +27,8 @@ class ClientDLL : public IHookableNameFilter
 	HOOK_DECL(void, __cdecl, VectorTransform, float *in1, float *in2, float *out)
 	HOOK_DECL(void, __cdecl, EV_GetDefaultShellInfo, event_args_t *args, float *origin, float *velocity, float *ShellVelocity, float *ShellOrigin,
 	          float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale)
+	HOOK_DECL(void, __fastcall, CStudioModelRenderer__StudioSetupBones, void* thisptr)
+	HOOK_DECL(void, __cdecl, CStudioModelRenderer__StudioSetupBones_Linux, void* thisptr)
 
 public:
 	static ClientDLL& GetInstance()

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -55,6 +55,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, S_StartDynamicSound, int entnum, int entchannel, void *sfx, vec_t *origin,
 	                                              float fvol, float attenuation, int flags, int pitch)
 	HOOK_DECL(void, __cdecl, VGuiWrap2_NotifyOfServerConnect, const char *game, int IP, int port)
+	HOOK_DECL(void, __cdecl, R_StudioSetupBones)
 
 	struct cmdbuf_t
 	{
@@ -446,6 +447,7 @@ protected:
 	cvar_t **cvar_vars;
 	void *movevars;
 	ptrdiff_t offZmax;
+	studiohdr_t **pstudiohdr;
 
 	int framesTillExecuting;
 	bool executing;

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -414,6 +414,13 @@ namespace patterns
 			"HL-NGHL",
 			"8B 0D ?? ?? ?? ?? 33 C0 3B C8 74 2E A3 ?? ?? ?? ?? A2"
 		);
+
+		PATTERNS(R_StudioSetupBones,
+			"HL-SteamPipe",
+			"55 8B EC 83 EC 48 A1 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 53 56 8B 90",
+			"HL-4554",
+			"A1 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 83 EC 48 8B 90"
+		);
 	}
 
 	namespace server
@@ -595,6 +602,25 @@ namespace patterns
 			"55 8B EC 83 EC 1C 56 8D 4D ?? E8 ?? ?? ?? ?? 8B 45",
 			"AoMDC",
 			"55 8B EC 83 EC 5C 53 56 57 8D 4D ?? E8 ?? ?? ?? ?? 8B 45"
+		);
+
+		PATTERNS(CStudioModelRenderer__StudioSetupBones,
+			"HL-SteamPipe",
+			"83 EC 48 53 8B D9 55 56 8B 43 30 8B 4B 44",
+			"HL-WON",
+			"83 EC 48 53 55 56 8B F1 57 8B 46 30 8B 4E 44",
+			"CSCZDS",
+			"83 EC 4C 53 55 8B E9 56 57 8B 45 44",
+			"HL-Restored",
+			"55 8B EC 83 E4 F8 83 EC 54 53",
+			"Echoes",
+			"55 8B EC 81 EC 90 00 00 00 89 4D",
+			"They Hunger Trilogy",
+			"55 8B EC 81 EC 94 00 00 00 89 4D",
+			"PARANOIA",
+			"55 8B EC 81 EC A4 00 00 00 89 4D",
+			"AoMDC",
+			"55 8B EC 81 EC D0 00 00 00 53 56 57 89 4D"
 		);
 	}
 

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -60,6 +60,7 @@ using std::ptrdiff_t;
 #include "HLSDK/common/com_model.h"
 #include "HLSDK/common/cl_entity.h"
 #include "HLSDK/common/event_args.h"
+#include "HLSDK/engine/studio.h"
 
 typedef int(*pfnUserMsgHook)(const char *pszName, int iSize, void *pbuf);
 #include "HLSDK/engine/cdll_int.h"

--- a/HLSDK/engine/studio.h
+++ b/HLSDK/engine/studio.h
@@ -1,0 +1,365 @@
+/***
+*
+*	Copyright (c) 1996-2002, Valve LLC. All rights reserved.
+*	
+*	This product contains software technology licensed from Id 
+*	Software, Inc. ("Id Technology").  Id Technology (c) 1996 Id Software, Inc. 
+*	All Rights Reserved.
+*
+*   Use, distribution, and modification of this source code and/or resulting
+*   object code is restricted to non-commercial enhancements to products from
+*   Valve LLC.  All other use, distribution, or modification is prohibited
+*   without written permission from Valve LLC.
+*
+****/
+
+
+
+
+#ifndef _STUDIO_H_
+#define _STUDIO_H_
+
+/*
+==============================================================================
+
+STUDIO MODELS
+
+Studio models are position independent, so the cache manager can move them.
+==============================================================================
+*/
+ 
+
+#define MAXSTUDIOTRIANGLES	20000	// TODO: tune this
+#define MAXSTUDIOVERTS		2048	// TODO: tune this
+#define MAXSTUDIOSEQUENCES	2048	// total animation sequences -- KSH incremented
+#define MAXSTUDIOSKINS		100		// total textures
+#define MAXSTUDIOSRCBONES	512		// bones allowed at source movement
+#define MAXSTUDIOBONES		128		// total bones actually used
+#define MAXSTUDIOMODELS		32		// sub-models per model
+#define MAXSTUDIOBODYPARTS	32
+#define MAXSTUDIOGROUPS		16
+#define MAXSTUDIOANIMATIONS	2048		
+#define MAXSTUDIOMESHES		256
+#define MAXSTUDIOEVENTS		1024
+#define MAXSTUDIOPIVOTS		256
+#define MAXSTUDIOCONTROLLERS 8
+
+typedef struct 
+{
+	int					id;
+	int					version;
+
+	char				name[64];
+	int					length;
+
+	vec3_t				eyeposition;	// ideal eye position
+	vec3_t				min;			// ideal movement hull size
+	vec3_t				max;			
+
+	vec3_t				bbmin;			// clipping bounding box
+	vec3_t				bbmax;		
+
+	int					flags;
+
+	int					numbones;			// bones
+	int					boneindex;
+
+	int					numbonecontrollers;		// bone controllers
+	int					bonecontrollerindex;
+
+	int					numhitboxes;			// complex bounding boxes
+	int					hitboxindex;			
+	
+	int					numseq;				// animation sequences
+	int					seqindex;
+
+	int					numseqgroups;		// demand loaded sequences
+	int					seqgroupindex;
+
+	int					numtextures;		// raw textures
+	int					textureindex;
+	int					texturedataindex;
+
+	int					numskinref;			// replaceable textures
+	int					numskinfamilies;
+	int					skinindex;
+
+	int					numbodyparts;		
+	int					bodypartindex;
+
+	int					numattachments;		// queryable attachable points
+	int					attachmentindex;
+
+	int					soundtable;
+	int					soundindex;
+	int					soundgroups;
+	int					soundgroupindex;
+
+	int					numtransitions;		// animation node to animation node transition graph
+	int					transitionindex;
+} studiohdr_t;
+
+// header for demand loaded sequence group data
+typedef struct 
+{
+	int					id;
+	int					version;
+
+	char				name[64];
+	int					length;
+} studioseqhdr_t;
+
+// bones
+typedef struct 
+{
+	char				name[32];	// bone name for symbolic links
+	int		 			parent;		// parent bone
+	int					flags;		// ??
+	int					bonecontroller[6];	// bone controller index, -1 == none
+	float				value[6];	// default DoF values
+	float				scale[6];   // scale for delta DoF values
+} mstudiobone_t;
+
+
+// bone controllers
+typedef struct 
+{
+	int					bone;	// -1 == 0
+	int					type;	// X, Y, Z, XR, YR, ZR, M
+	float				start;
+	float				end;
+	int					rest;	// byte index value at rest
+	int					index;	// 0-3 user set controller, 4 mouth
+} mstudiobonecontroller_t;
+
+// intersection boxes
+typedef struct
+{
+	int					bone;
+	int					group;			// intersection group
+	vec3_t				bbmin;		// bounding box
+	vec3_t				bbmax;		
+} mstudiobbox_t;
+
+#if !defined( CACHE_USER ) && !defined( QUAKEDEF_H )
+#define CACHE_USER
+typedef struct cache_user_s
+{
+	void *data;
+} cache_user_t;
+#endif
+
+//
+// demand loaded sequence groups
+//
+typedef struct
+{
+	char				label[32];	// textual name
+	char				name[64];	// file name
+    int					unused1;    // was "cache"  - index pointer
+	int					unused2;    // was "data" -  hack for group 0
+} mstudioseqgroup_t;
+
+// sequence descriptions
+typedef struct
+{
+	char				label[32];	// sequence label
+
+	float				fps;		// frames per second	
+	int					flags;		// looping/non-looping flags
+
+	int					activity;
+	int					actweight;
+
+	int					numevents;
+	int					eventindex;
+
+	int					numframes;	// number of frames per sequence
+
+	int					numpivots;	// number of foot pivots
+	int					pivotindex;
+
+	int					motiontype;	
+	int					motionbone;
+	vec3_t				linearmovement;
+	int					automoveposindex;
+	int					automoveangleindex;
+
+	vec3_t				bbmin;		// per sequence bounding box
+	vec3_t				bbmax;		
+
+	int					numblends;
+	int					animindex;		// mstudioanim_t pointer relative to start of sequence group data
+										// [blend][bone][X, Y, Z, XR, YR, ZR]
+
+	int					blendtype[2];	// X, Y, Z, XR, YR, ZR
+	float				blendstart[2];	// starting value
+	float				blendend[2];	// ending value
+	int					blendparent;
+
+	int					seqgroup;		// sequence group for demand loading
+
+	int					entrynode;		// transition node at entry
+	int					exitnode;		// transition node at exit
+	int					nodeflags;		// transition rules
+	
+	int					nextseq;		// auto advancing sequences
+} mstudioseqdesc_t;
+
+// events
+typedef struct 
+{
+	int 				frame;
+	int					event;
+	int					type;
+	char				options[64];
+} mstudioevent_t;
+
+// pivots
+typedef struct 
+{
+	vec3_t				org;	// pivot point
+	int					start;
+	int					end;
+} mstudiopivot_t;
+
+// attachment
+typedef struct 
+{
+	char				name[32];
+	int					type;
+	int					bone;
+	vec3_t				org;	// attachment point
+	vec3_t				vectors[3];
+} mstudioattachment_t;
+
+typedef struct
+{
+	unsigned short	offset[6];
+} mstudioanim_t;
+
+// animation frames
+typedef union 
+{
+	struct {
+		byte	valid;
+		byte	total;
+	} num;
+	short		value;
+} mstudioanimvalue_t;
+
+
+
+// body part index
+typedef struct
+{
+	char				name[64];
+	int					nummodels;
+	int					base;
+	int					modelindex; // index into models array
+} mstudiobodyparts_t;
+
+
+
+// skin info
+typedef struct
+{
+	char					name[64];
+	int						flags;
+	int						width;
+	int						height;
+	int						index;
+} mstudiotexture_t;
+
+
+// skin families
+// short	index[skinfamilies][skinref]
+
+// studio models
+typedef struct
+{
+	char				name[64];
+
+	int					type;
+
+	float				boundingradius;
+
+	int					nummesh;
+	int					meshindex;
+
+	int					numverts;		// number of unique vertices
+	int					vertinfoindex;	// vertex bone info
+	int					vertindex;		// vertex vec3_t
+	int					numnorms;		// number of unique surface normals
+	int					norminfoindex;	// normal bone info
+	int					normindex;		// normal vec3_t
+
+	int					numgroups;		// deformation groups
+	int					groupindex;
+} mstudiomodel_t;
+
+
+// vec3_t	boundingbox[model][bone][2];	// complex intersection info
+
+
+// meshes
+typedef struct 
+{
+	int					numtris;
+	int					triindex;
+	int					skinref;
+	int					numnorms;		// per mesh normals
+	int					normindex;		// normal vec3_t
+} mstudiomesh_t;
+
+// triangles
+#if 0
+typedef struct 
+{
+	short				vertindex;		// index into vertex array
+	short				normindex;		// index into normal array
+	short				s,t;			// s,t position on skin
+} mstudiotrivert_t;
+#endif
+
+// lighting options
+#define STUDIO_NF_FLATSHADE		0x0001
+#define STUDIO_NF_CHROME		0x0002
+#define STUDIO_NF_FULLBRIGHT	0x0004
+#define STUDIO_NF_NOMIPS        0x0008
+#define STUDIO_NF_ALPHA         0x0010
+#define STUDIO_NF_ADDITIVE      0x0020
+#define STUDIO_NF_MASKED        0x0040
+
+// motion flags
+#define STUDIO_X		0x0001
+#define STUDIO_Y		0x0002	
+#define STUDIO_Z		0x0004
+#define STUDIO_XR		0x0008
+#define STUDIO_YR		0x0010
+#define STUDIO_ZR		0x0020
+#define STUDIO_LX		0x0040
+#define STUDIO_LY		0x0080
+#define STUDIO_LZ		0x0100
+#define STUDIO_AX		0x0200
+#define STUDIO_AY		0x0400
+#define STUDIO_AZ		0x0800
+#define STUDIO_AXR		0x1000
+#define STUDIO_AYR		0x2000
+#define STUDIO_AZR		0x4000
+#define STUDIO_TYPES	0x7FFF
+#define STUDIO_RLOOP	0x8000	// controller that wraps shortest distance
+
+// sequence flags
+#define STUDIO_LOOPING	0x0001
+
+// bone flags
+#define STUDIO_HAS_NORMALS	0x0001
+#define STUDIO_HAS_VERTICES 0x0002
+#define STUDIO_HAS_BBOX		0x0004
+#define STUDIO_HAS_CHROME	0x0008	// if any of the textures have chrome on them
+
+#define RAD_TO_STUDIO		(32768.0/M_PI)
+#define STUDIO_TO_RAD		(M_PI/32768.0)
+
+#endif


### PR DESCRIPTION
Based on the OpenAG implementation, thanks @chinese-soup.
Engine hook for old WON mods, everything else uses client's function