### PR TITLE
Added bxt_force_duck

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -53,6 +53,7 @@ namespace CVars
 	CVarWrapper bxt_show_pickup_bbox("bxt_show_pickup_bbox", "0");
 	CVarWrapper bxt_disable_autosave("bxt_disable_autosave", "0");
 	CVarWrapper bxt_disable_changelevel("bxt_disable_changelevel", "0");
+	CVarWrapper bxt_force_duck("bxt_force_duck", "0");
 
 	// Clientside CVars
 	CVarWrapper bxt_disable_hud("bxt_disable_hud", "0");

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -166,6 +166,7 @@ namespace CVars
 	extern CVarWrapper bxt_show_pickup_bbox;
 	extern CVarWrapper bxt_disable_autosave;
 	extern CVarWrapper bxt_disable_changelevel;
+	extern CVarWrapper bxt_force_duck;
 
 	// Clientside CVars
 	extern CVarWrapper bxt_disable_hud;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -803,6 +803,7 @@ void ServerDLL::FindStuff()
 	ORIG_AddToFullPack = reinterpret_cast<_AddToFullPack>(MemUtils::GetSymbolAddress(m_Handle, "_Z13AddToFullPackP14entity_state_siP7edict_sS2_iiPh"));
 	ORIG_ClientCommand = reinterpret_cast<_ClientCommand>(MemUtils::GetSymbolAddress(m_Handle, "_Z13ClientCommandP7edict_s"));
 	ORIG_PM_Move = reinterpret_cast<_PM_Move>(MemUtils::GetSymbolAddress(m_Handle, "PM_Move"));
+
 	if (ORIG_CmdStart && ORIG_AddToFullPack && ORIG_ClientCommand && ORIG_PM_Move) {
 		EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
 		EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
@@ -1149,6 +1150,8 @@ void ServerDLL::RegisterCVarsAndCommands()
 		REG(bxt_disable_autosave);
 	if (ORIG_CChangeLevel__UseChangeLevel && ORIG_CChangeLevel__TouchChangeLevel)
 		REG(bxt_disable_changelevel);
+	if (ORIG_PM_PlayerMove)
+		REG(bxt_force_duck);
 	#undef REG
 }
 
@@ -1285,6 +1288,9 @@ HOOK_DEF_1(ServerDLL, void, __cdecl, PM_PlayerMove, qboolean, server)
 	origin =   reinterpret_cast<float*>(pmove + offOrigin);
 	angles =   reinterpret_cast<float*>(pmove + offAngles);
 	usercmd_t *cmd = reinterpret_cast<usercmd_t*>(pmove + offCmd);
+
+	if (CVars::bxt_force_duck.GetBool())
+		cmd->buttons |= IN_DUCK;
 
 	#define ALERT(at, format, ...) pEngfuncs->pfnAlertMessage(at, const_cast<char*>(format), ##__VA_ARGS__)
 	if (CVars::_bxt_taslog.GetBool() && pEngfuncs)


### PR DESCRIPTION
For +duck category without them pausing cheats. https://www.speedrun.com/hl1ce#%2Bduck

hello @hobokenn, my patterns are probably all wrong and stupid, I couldn't test the WON one at all (no win machine, VM hates me with sw.dll bs error), the Steam one only matched for ClientDLL for some reason (even though in Ghidra it finds it in both Client and Server DLLs), I commented/removed the pattern code out in client DLL because for some reason having FindAsync() crashed the game on Linux. :| Please end my misery.


> [17:22] although, i can't get my Steampipe pattern to work on ServerDLL (only ClientDLL) and I can't get my WON to work at all, so I can't test it there at all, ummm calling 800-hoboken :CoolStoryBob:
> [17:22] not using ppmove in some other more top-level PM_xxx function becauase that would require pm_shared/ engine headers and those are in conflict with the linux hooks etc. etc. so fuck that, easiest & cleanest solution is imho this one, aka just hooking PM_UnDuck and not calling it at all if +duck meme run cvar is on, it's a meme category anyway
> [17:23] tiem to check for spaces b4 PR LMAO
> [17:24] also the ClientDLL hook is pretty much useless imo, for this +duck usecase, anyway
> [17:24] cuz when you pause/unpause only the ServerDLL's PM_UnDuck is called 
