### PR TITLE
Added bxt_show_hidden_entities_clientside

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -50,6 +50,7 @@ namespace CVars
 	CVarWrapper bxt_bhopcap("bxt_bhopcap", "1");
 	CVarWrapper bxt_timer_autostop("bxt_timer_autostop", "1");
 	CVarWrapper bxt_show_hidden_entities("bxt_show_hidden_entities", "0");
+	CVarWrapper bxt_show_hidden_entities_clientside("bxt_show_hidden_entities_clientside", "0");
 	CVarWrapper bxt_show_triggers_legacy("bxt_show_triggers_legacy", "0");
 	CVarWrapper bxt_show_pickup_bbox("bxt_show_pickup_bbox", "0");
 	CVarWrapper bxt_disable_autosave("bxt_disable_autosave", "0");
@@ -187,6 +188,7 @@ namespace CVars
 		&bxt_bhopcap,
 		&bxt_timer_autostop,
 		&bxt_show_hidden_entities,
+		&bxt_show_hidden_entities_clientside,
 		&bxt_autojump_prediction,
 		&bxt_bhopcap_prediction,
 		&bxt_show_nodes,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -163,6 +163,7 @@ namespace CVars
 	extern CVarWrapper bxt_bhopcap;
 	extern CVarWrapper bxt_timer_autostop;
 	extern CVarWrapper bxt_show_hidden_entities;
+	extern CVarWrapper bxt_show_hidden_entities_clientside;
 	extern CVarWrapper bxt_show_triggers_legacy;
 	extern CVarWrapper bxt_show_pickup_bbox;
 	extern CVarWrapper bxt_disable_autosave;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -113,6 +113,7 @@ void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* m
 	MemUtils::AddSymbolLookupHook(moduleHandle, reinterpret_cast<void*>(ORIG_HUD_DrawTransparentTriangles), reinterpret_cast<void*>(HOOKED_HUD_DrawTransparentTriangles));
 	MemUtils::AddSymbolLookupHook(moduleHandle, reinterpret_cast<void*>(ORIG_HUD_Key_Event), reinterpret_cast<void*>(HOOKED_HUD_Key_Event));
 	MemUtils::AddSymbolLookupHook(moduleHandle, reinterpret_cast<void*>(ORIG_HUD_UpdateClientData), reinterpret_cast<void*>(HOOKED_HUD_UpdateClientData));
+	MemUtils::AddSymbolLookupHook(moduleHandle, reinterpret_cast<void*>(ORIG_HUD_AddEntity), reinterpret_cast<void*>(HOOKED_HUD_AddEntity));
 
 	if (needToIntercept)
 	{
@@ -129,6 +130,7 @@ void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* m
 			ORIG_HUD_DrawTransparentTriangles, HOOKED_HUD_DrawTransparentTriangles,
 			ORIG_HUD_Key_Event, HOOKED_HUD_Key_Event,
 			ORIG_HUD_UpdateClientData, HOOKED_HUD_UpdateClientData,
+			ORIG_HUD_AddEntity, HOOKED_HUD_AddEntity,
 			ORIG_EV_GetDefaultShellInfo, HOOKED_EV_GetDefaultShellInfo,
 			ORIG_StudioCalcAttachments, HOOKED_StudioCalcAttachments,
 			ORIG_VectorTransform, HOOKED_VectorTransform,
@@ -159,6 +161,7 @@ void ClientDLL::Unhook()
 			ORIG_HUD_DrawTransparentTriangles,
 			ORIG_HUD_Key_Event,
 			ORIG_HUD_UpdateClientData,
+			ORIG_HUD_AddEntity,
 			ORIG_EV_GetDefaultShellInfo,
 			ORIG_StudioCalcAttachments,
 			ORIG_VectorTransform,
@@ -174,6 +177,7 @@ void ClientDLL::Unhook()
 	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_DrawTransparentTriangles));
 	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_Key_Event));
 	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_UpdateClientData));
+	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_AddEntity));
 
 	Clear();
 }
@@ -203,6 +207,7 @@ void ClientDLL::Clear()
 	ORIG_HUD_DrawTransparentTriangles = nullptr;
 	ORIG_HUD_Key_Event = nullptr;
 	ORIG_HUD_UpdateClientData = nullptr;
+	ORIG_HUD_AddEntity = nullptr;
 	ORIG_IN_ActivateMouse = nullptr;
 	ORIG_IN_DeactivateMouse = nullptr;
 	ppmove = nullptr;
@@ -459,6 +464,14 @@ void ClientDLL::FindStuff()
 		EngineDevWarning("[client dll] Could not find HUD_UpdateClientData.\n");
 	}
 
+	ORIG_HUD_AddEntity = reinterpret_cast<_HUD_AddEntity>(MemUtils::GetSymbolAddress(m_Handle, "HUD_AddEntity"));
+	if (ORIG_HUD_AddEntity) {
+		EngineDevMsg("[client dll] Found HUD_AddEntity at %p.\n", ORIG_HUD_AddEntity);
+	} else {
+		EngineDevWarning("[client dll] Could not find HUD_AddEntity.\n");
+		EngineWarning("bxt_show_hidden_entities_clientside is not available.\n");
+	}
+
 	ORIG_IN_ActivateMouse = reinterpret_cast<_IN_ActivateMouse>(MemUtils::GetSymbolAddress(m_Handle, "IN_ActivateMouse"));
 	if (ORIG_IN_ActivateMouse) {
 		EngineDevMsg("[client dll] Found IN_ActivateMouse at %p.\n", ORIG_IN_ActivateMouse);
@@ -590,14 +603,6 @@ bool ClientDLL::FindHUDFunctions()
 	} else {
 		EngineDevWarning("[client dll] Could not find HUD_Redraw.\n");
 		EngineWarning("bxt_disable_hud is not available.\n");
-		return false;
-	}
-
-	if ((ORIG_HUD_AddEntity = reinterpret_cast<_HUD_AddEntity>(MemUtils::GetSymbolAddress(m_Handle, "HUD_AddEntity")))) {
-		EngineDevMsg("[client dll] Found HUD_AddEntity at %p.\n", HUD_AddEntity);
-	} else {
-		EngineDevWarning("[client dll] Could not find HUD_AddEntity.\n");
-		EngineWarning("bxt_show_hidden_entities_clientside is not available.\n");
 		return false;
 	}
 

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1153,8 +1153,8 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, CStudioModelRenderer__StudioSetupBones_Linu
 HOOK_DEF_3(ClientDLL, int, __cdecl, HUD_AddEntity, int, type, cl_entity_s*, ent, char*, modelname)
 {
 	if (CVars::bxt_show_hidden_entities_clientside.GetBool()) {
-		ent->curstate.effects &= ~EF_NODRAW;
-		ent->curstate.rendermode = kRenderNormal;
+		if (ent->curstate.rendermode != kRenderNormal)
+			ent->curstate.renderamt = 255;
 	}
 
 	return ORIG_HUD_AddEntity(type, ent, modelname);

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -29,6 +29,7 @@ class ClientDLL : public IHookableNameFilter
 	          float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale)
 	HOOK_DECL(void, __fastcall, CStudioModelRenderer__StudioSetupBones, void* thisptr)
 	HOOK_DECL(void, __cdecl, CStudioModelRenderer__StudioSetupBones_Linux, void* thisptr)
+	HOOK_DECL(int, __cdecl, HUD_AddEntity, int type, cl_entity_s *ent, char *modelname)
 
 public:
 	static ClientDLL& GetInstance()

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1738,7 +1738,18 @@ HOOK_DEF_7(ServerDLL, int, __cdecl, AddToFullPack, struct entity_state_s*, state
 			ent->v.effects &= ~EF_NODRAW;
 			ent->v.rendermode = kRenderNormal;
 		}
-	} else if (is_trigger && CVars::bxt_show_triggers_legacy.GetBool()) {
+	} else if (!is_trigger && CVars::bxt_show_hidden_entities_clientside.GetBool()) {
+		if (ent->v.effects & EF_NODRAW)
+		{
+			ent->v.effects &= ~EF_NODRAW;
+			ent->v.renderamt = 0;
+
+			// e.g. func_wall_toggle is kRenderNormal when it's EF_NODRAW'd, so that'd make it visible always, fix that
+			if (ent->v.rendermode == kRenderNormal)
+				ent->v.rendermode = kRenderTransTexture;
+		}
+	}
+	else if (is_trigger && CVars::bxt_show_triggers_legacy.GetBool()) {
 		ent->v.effects &= ~EF_NODRAW;
 		ent->v.rendermode = kRenderTransColor;
 		if (ent->v.solid == SOLID_NOT && std::strcmp(classname + 8, "transition") != 0)


### PR DESCRIPTION
Fixes #143

https://user-images.githubusercontent.com/5108747/140078906-ab4c2a6f-0728-4cdd-8573-5d7e3e88c185.mp4

* no time, no energy, no windows = no windows, PRs welcome (otherwise imma do it later myself)
* lemme know if renderamt > 0 check like in serverDLL version (where bxt_show_hidden_entities 1 means renderamt > 0 entities aren't set to kRenderNormal AND bxt_show_hidden_entities 2 means even renderamt > 0 are set to kRenderNormal) is preferred here as well
* too lazy to implement the legacy triggers part as it is in ServerDLL, because ent in HUD_AddEntity has no classname, meh
