### PR TITLE
Fix `bxt_autorecord` crash in CS:CZDS on Linux

### DIFF
--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -746,6 +746,16 @@ void ClientDLL::StudioAdjustViewmodelAttachments(Vector &vOrigin)
 	vOrigin = last_vieworg + vOut;
 }
 
+bool ClientDLL::DoesGameDirMatch(const char *game)
+{
+	if (!pEngfuncs)
+		return false;
+
+	const char *gameDir = pEngfuncs->pfnGetGameDirectory();
+
+	return !std::strcmp(gameDir, game);
+}
+
 HOOK_DEF_0(ClientDLL, void, __cdecl, PM_Jump)
 {
 	auto pmove = reinterpret_cast<uintptr_t>(*ppmove);

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -55,6 +55,8 @@ public:
 
 	void StudioAdjustViewmodelAttachments(Vector &vOrigin);
 
+	bool DoesGameDirMatch(const char *game);
+
 	unsigned short last_buttons;
 
 	// When set to false, the mouse won't move the camera.

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -672,6 +672,10 @@ void ServerDLL::FindStuff()
 				maxAmmoSlots = MAX_AMMO_SLOTS;
 				offm_rgAmmoLast = 0x56C; // 6153: 0x568
 				offm_iClientFOV = 0x4C4; // 6153: 0x4C0
+				if (ClientDLL::GetInstance().DoesGameDirMatch("czeror")) {
+					offm_rgAmmoLast = 0x554;
+					offm_iClientFOV = 0x8B0;
+				}
 				EngineDevMsg("[server dll] Found CBasePlayer::ForceClientDllUpdate [Linux] at %p.\n", ORIG_CBasePlayer__ForceClientDllUpdate_Linux);
 			} else {
 				EngineDevWarning("[server dll] Could not find CBasePlayer::ForceClientDllUpdate.\n");


### PR DESCRIPTION
CZDS doesn't have ammo HUD reset bug. Closes #216.