### PR TITLE
Add viewmodel offset cvars

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -143,6 +143,9 @@ namespace CVars
 	CVarWrapper bxt_cross_bottom_line("bxt_cross_bottom_line", "1");
 	CVarWrapper bxt_cross_left_line("bxt_cross_left_line", "1");
 	CVarWrapper bxt_cross_right_line("bxt_cross_right_line", "1");
+	CVarWrapper bxt_viewmodel_ofs_forward("bxt_viewmodel_ofs_forward", "0");
+	CVarWrapper bxt_viewmodel_ofs_right("bxt_viewmodel_ofs_right", "0");
+	CVarWrapper bxt_viewmodel_ofs_up("bxt_viewmodel_ofs_up", "0");
 
 	const std::vector<CVarWrapper*> allCVars =
 	{
@@ -277,6 +280,9 @@ namespace CVars
 		&bxt_cross_top_line,
 		&bxt_cross_bottom_line,
 		&bxt_cross_left_line,
-		&bxt_cross_right_line
+		&bxt_cross_right_line,
+		&bxt_viewmodel_ofs_forward,
+		&bxt_viewmodel_ofs_right,
+		&bxt_viewmodel_ofs_up
 	};
 }

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -256,6 +256,9 @@ namespace CVars
 	extern CVarWrapper bxt_cross_bottom_line;
 	extern CVarWrapper bxt_cross_left_line;
 	extern CVarWrapper bxt_cross_right_line;
+	extern CVarWrapper bxt_viewmodel_ofs_forward;
+	extern CVarWrapper bxt_viewmodel_ofs_right;
+	extern CVarWrapper bxt_viewmodel_ofs_up;
 
 	extern const std::vector<CVarWrapper*> allCVars;
 }

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -72,6 +72,8 @@ protected:
 	_IN_ActivateMouse ORIG_IN_ActivateMouse;
 	typedef void(__cdecl *_IN_DeactivateMouse) ();
 	_IN_DeactivateMouse ORIG_IN_DeactivateMouse;
+	typedef int(__cdecl *_CL_IsThirdPerson) ();
+	_CL_IsThirdPerson ORIG_CL_IsThirdPerson;
 
 	void FindStuff();
 	bool FindHUDFunctions();


### PR DESCRIPTION
Based on the OpenAG implementation, thanks soup & tmp64. Didn't include `EV_IsPlayer` and `EV_IsLocal` checks in `EV_GetDefaultShellInfo` like in OpenAG because they are meant for multiplayer(?), might be wrong:
```cpp
if (pEngfuncs && ORIG_CL_IsThirdPerson) {
	if ((args->entindex >= 1 && args->entindex <= pEngfuncs->GetMaxClients()) && // Is the entity's index in the player range?
		pEngfuncs->pEventAPI->EV_IsLocal(args->entindex - 1) && // Is the entity == the local player
		!ORIG_CL_IsThirdPerson()) {
		rightScale += CVars::bxt_viewmodel_ofs_right.GetFloat();
		forwardScale += CVars::bxt_viewmodel_ofs_forward.GetFloat();
		upScale += CVars::bxt_viewmodel_ofs_up.GetFloat();
	}
}
```