### PR TITLE
Added a HUD for draw armor in float value

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -100,6 +100,9 @@ namespace CVars
 	CVarWrapper bxt_hud_selfgauss("bxt_hud_selfgauss", "0");
 	CVarWrapper bxt_hud_selfgauss_offset("bxt_hud_selfgauss_offset", "");
 	CVarWrapper bxt_hud_selfgauss_anchor("bxt_hud_selfgauss_anchor", "1 0");
+	CVarWrapper bxt_hud_armor("bxt_hud_armor", "0");
+	CVarWrapper bxt_hud_armor_offset("bxt_hud_armor_offset", "");
+	CVarWrapper bxt_hud_armor_anchor("bxt_hud_armor_anchor", "1 0");
 	CVarWrapper bxt_hud_speedometer("bxt_hud_speedometer", "1");
 	CVarWrapper bxt_hud_speedometer_offset("bxt_hud_speedometer_offset", "");
 	CVarWrapper bxt_hud_speedometer_anchor("bxt_hud_speedometer_anchor", "0.5 1");
@@ -239,6 +242,9 @@ namespace CVars
 		&bxt_hud_selfgauss,
 		&bxt_hud_selfgauss_offset,
 		&bxt_hud_selfgauss_anchor,
+		&bxt_hud_armor,
+		&bxt_hud_armor_offset,
+		&bxt_hud_armor_anchor,
 		&bxt_hud_speedometer,
 		&bxt_hud_speedometer_offset,
 		&bxt_hud_speedometer_anchor,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -213,6 +213,9 @@ namespace CVars
 	extern CVarWrapper bxt_hud_selfgauss;
 	extern CVarWrapper bxt_hud_selfgauss_offset;
 	extern CVarWrapper bxt_hud_selfgauss_anchor;
+	extern CVarWrapper bxt_hud_armor;
+	extern CVarWrapper bxt_hud_armor_offset;
+	extern CVarWrapper bxt_hud_armor_anchor;
 	extern CVarWrapper bxt_hud_speedometer;
 	extern CVarWrapper bxt_hud_speedometer_offset;
 	extern CVarWrapper bxt_hud_speedometer_anchor;

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -398,7 +398,7 @@ namespace CustomHud
 
 	void GetAccurateInfo()
 	{
-		receivedAccurateInfo = HwDLL::GetInstance().TryGettingAccurateInfo(player.origin, player.velocity, player.health);
+		receivedAccurateInfo = HwDLL::GetInstance().TryGettingAccurateInfo(player.origin, player.velocity, player.health, player.armorvalue);
 		HwDLL::GetInstance().GetViewangles(player.viewangles);
 	}
 
@@ -860,6 +860,22 @@ namespace CustomHud
 		}
 	}
 
+	void DrawArmor(float flTime)
+	{
+		if (CVars::bxt_hud_armor.GetBool())
+		{
+			int x, y;
+			GetPosition(CVars::bxt_hud_armor_offset, CVars::bxt_hud_armor_anchor, &x, &y, -200, (si.iCharHeight * 30) + 3);
+
+			std::ostringstream out;
+			out.setf(std::ios::fixed);
+			out.precision(precision);
+			out << "Armor: " << player.armorvalue;
+
+			DrawMultilineString(x, y, out.str());
+		}
+	}
+
 	void DrawNihilanthInfo(float flTime)
 	{
 		static const char *IRRITATIONS[4] = {"Idle", "Attacking", "Opened", "Killed"};
@@ -867,7 +883,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_nihilanth.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 30) + 3);
+			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 31) + 3);
 
 			std::ostringstream out;
 			out << "Nihilanth:\n";
@@ -901,7 +917,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_gonarch.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 37) + 3);
+			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 38) + 3);
 
 			std::ostringstream out;
 			out << "Gonarch:\n";
@@ -1074,7 +1090,7 @@ namespace CustomHud
 			return;
 
 		int x, y;
-		GetPosition(CVars::bxt_hud_tas_editor_status_offset, CVars::bxt_hud_tas_editor_status_anchor, &x, &y, -250, (si.iCharHeight * 40) + 3);
+		GetPosition(CVars::bxt_hud_tas_editor_status_offset, CVars::bxt_hud_tas_editor_status_anchor, &x, &y, -250, (si.iCharHeight * 41) + 3);
 
 		std::ostringstream out;
 		out.setf(std::ios::fixed);
@@ -1415,6 +1431,7 @@ namespace CustomHud
 
 		DrawQuickGauss(flTime);
 		DrawHealth(flTime);
+		DrawArmor(flTime);
 		DrawVelocity(flTime);
 		DrawOrigin(flTime);
 		DrawViewangles(flTime);

--- a/BunnymodXT/hud_custom.hpp
+++ b/BunnymodXT/hud_custom.hpp
@@ -10,6 +10,7 @@ namespace CustomHud
 		float velocity[3];
 		float viewangles[3];
 		float health;
+		float armorvalue;
 	} playerinfo;
 
 	void Init();

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -689,6 +689,9 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_hud_selfgauss);
 		REG(bxt_hud_selfgauss_offset);
 		REG(bxt_hud_selfgauss_anchor);
+		REG(bxt_hud_armor);
+		REG(bxt_hud_armor_offset);
+		REG(bxt_hud_armor_anchor);
 		REG(bxt_hud_speedometer);
 		REG(bxt_hud_speedometer_offset);
 		REG(bxt_hud_speedometer_anchor);

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4460,7 +4460,7 @@ void HwDLL::SetPlayerVelocity(float velocity[3])
 	player.Velocity[2] = velocity[2];
 }
 
-bool HwDLL::TryGettingAccurateInfo(float origin[3], float velocity[3], float& health)
+bool HwDLL::TryGettingAccurateInfo(float origin[3], float velocity[3], float& health, float& armorvalue)
 {
 	if (!svs || svs->num_clients < 1)
 		return false;
@@ -4476,6 +4476,7 @@ bool HwDLL::TryGettingAccurateInfo(float origin[3], float velocity[3], float& he
 	velocity[1] = pl->v.velocity[1];
 	velocity[2] = pl->v.velocity[2];
 	health = pl->v.health;
+	armorvalue = pl->v.armorvalue;
 
 	return true;
 }

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -158,7 +158,7 @@ public:
 
 	void SetPlayerOrigin(float origin[3]);
 	void SetPlayerVelocity(float velocity[3]);
-	bool TryGettingAccurateInfo(float origin[3], float velocity[3], float& health);
+	bool TryGettingAccurateInfo(float origin[3], float velocity[3], float& health, float& armorvalue);
 	void GetViewangles(float* va);
 	void SetViewangles(float* va);
 


### PR DESCRIPTION
Matherunner hldoc:

![изображение](https://user-images.githubusercontent.com/58108407/146143072-3158a2a0-0df3-42f3-a733-3a9666ddb82a.png)

Useful in segmenting when u want to know how much armor you will get from pickup a battery or using a suit charger.

Half-Life HUD can draw that you had a 15 armor, but in truly you can have a 16 armor in the game (if the value is close to 16, e.g. 15.99)