### PR TITLE
Added SDL=true for bshift_cutsceneless (same DLLs as bshift)

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -1680,7 +1680,6 @@ void HwDLL::FindStuff()
 		GET_FUTURE(CL_Record_f)
 		GET_FUTURE(build_number);
 		GET_FUTURE(Key_Event);
-		GET_FUTURE(BIsValveGame);
 		#undef GET_FUTURE
 
 		{
@@ -1730,6 +1729,7 @@ void HwDLL::FindStuff()
 		GET_FUTURE(R_DrawWorld);
 		GET_FUTURE(R_DrawEntitiesOnList);
 		GET_FUTURE(R_DrawParticles);
+		GET_FUTURE(BIsValveGame);
 
 		if (oldEngine) {
 			GET_FUTURE(LoadAndDecryptHwDLL);
@@ -5378,10 +5378,10 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawParticles)
 	ORIG_R_DrawParticles();
 }
 
-HOOK_DEF_1(HwDLL, int, __fastcall, BIsValveGame, void*, thisptr)
+HOOK_DEF_0(HwDLL, int, __cdecl, BIsValveGame)
 {
 	if (ClientDLL::GetInstance().DoesGameDirMatch("bshift_cutsceneless"))
 		return true;
 	else
-		return ORIG_BIsValveGame(thisptr);
+		return ORIG_BIsValveGame();
 }

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -390,6 +390,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			MemUtils::MarkAsExecutable(ORIG_R_DrawWorld);
 			MemUtils::MarkAsExecutable(ORIG_R_DrawEntitiesOnList);
 			MemUtils::MarkAsExecutable(ORIG_R_DrawParticles);
+			MemUtils::MarkAsExecutable(ORIG_BIsValveGame);
 		}
 
 		MemUtils::Intercept(moduleName,
@@ -437,7 +438,8 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_CL_EmitEntities, HOOKED_CL_EmitEntities,
 			ORIG_R_DrawWorld, HOOKED_R_DrawWorld,
 			ORIG_R_DrawEntitiesOnList, HOOKED_R_DrawEntitiesOnList,
-			ORIG_R_DrawParticles, HOOKED_R_DrawParticles);
+			ORIG_R_DrawParticles, HOOKED_R_DrawParticles,
+			ORIG_BIsValveGame, HOOKED_BIsValveGame);
 	}
 }
 
@@ -490,7 +492,8 @@ void HwDLL::Unhook()
 			ORIG_CL_EmitEntities,
 			ORIG_R_DrawWorld,
 			ORIG_R_DrawEntitiesOnList,
-			ORIG_R_DrawParticles);
+			ORIG_R_DrawParticles,
+			ORIG_BIsValveGame);
 	}
 
 	for (auto cvar : CVars::allCVars)
@@ -569,6 +572,7 @@ void HwDLL::Clear()
 	ORIG_R_DrawWorld = nullptr;
 	ORIG_R_DrawEntitiesOnList = nullptr;
 	ORIG_R_DrawParticles = nullptr;
+	ORIG_BIsValveGame = nullptr;
 
 	registeredVarsAndCmds = false;
 	autojump = false;
@@ -1104,6 +1108,7 @@ void HwDLL::FindStuff()
 		DEF_FUTURE(R_DrawWorld)
 		DEF_FUTURE(R_DrawEntitiesOnList)
 		DEF_FUTURE(R_DrawParticles)
+		DEF_FUTURE(BIsValveGame)
 		#undef DEF_FUTURE
 
 		bool oldEngine = (m_Name.find(L"hl.exe") != std::wstring::npos);
@@ -1675,6 +1680,7 @@ void HwDLL::FindStuff()
 		GET_FUTURE(CL_Record_f)
 		GET_FUTURE(build_number);
 		GET_FUTURE(Key_Event);
+		GET_FUTURE(BIsValveGame);
 		#undef GET_FUTURE
 
 		{
@@ -5372,3 +5378,10 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawParticles)
 	ORIG_R_DrawParticles();
 }
 
+HOOK_DEF_1(HwDLL, int, __fastcall, BIsValveGame, void*, thisptr)
+{
+	if (ClientDLL::GetInstance().DoesGameDirMatch("bshift_cutsceneless"))
+		return true;
+	else
+		return ORIG_BIsValveGame(thisptr);
+}

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -390,7 +390,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			MemUtils::MarkAsExecutable(ORIG_R_DrawWorld);
 			MemUtils::MarkAsExecutable(ORIG_R_DrawEntitiesOnList);
 			MemUtils::MarkAsExecutable(ORIG_R_DrawParticles);
-			MemUtils::MarkAsExecutable(ORIG_BIsValveGame);
+			MemUtils::MarkAsExecutable(ORIG_BUsesSDLInput);
 		}
 
 		MemUtils::Intercept(moduleName,
@@ -439,7 +439,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_R_DrawWorld, HOOKED_R_DrawWorld,
 			ORIG_R_DrawEntitiesOnList, HOOKED_R_DrawEntitiesOnList,
 			ORIG_R_DrawParticles, HOOKED_R_DrawParticles,
-			ORIG_BIsValveGame, HOOKED_BIsValveGame);
+			ORIG_BUsesSDLInput, HOOKED_BUsesSDLInput);
 	}
 }
 
@@ -493,7 +493,7 @@ void HwDLL::Unhook()
 			ORIG_R_DrawWorld,
 			ORIG_R_DrawEntitiesOnList,
 			ORIG_R_DrawParticles,
-			ORIG_BIsValveGame);
+			ORIG_BUsesSDLInput);
 	}
 
 	for (auto cvar : CVars::allCVars)
@@ -572,7 +572,7 @@ void HwDLL::Clear()
 	ORIG_R_DrawWorld = nullptr;
 	ORIG_R_DrawEntitiesOnList = nullptr;
 	ORIG_R_DrawParticles = nullptr;
-	ORIG_BIsValveGame = nullptr;
+	ORIG_BUsesSDLInput = nullptr;
 
 	registeredVarsAndCmds = false;
 	autojump = false;
@@ -1108,7 +1108,7 @@ void HwDLL::FindStuff()
 		DEF_FUTURE(R_DrawWorld)
 		DEF_FUTURE(R_DrawEntitiesOnList)
 		DEF_FUTURE(R_DrawParticles)
-		DEF_FUTURE(BIsValveGame)
+		DEF_FUTURE(BUsesSDLInput)
 		#undef DEF_FUTURE
 
 		bool oldEngine = (m_Name.find(L"hl.exe") != std::wstring::npos);
@@ -1729,7 +1729,7 @@ void HwDLL::FindStuff()
 		GET_FUTURE(R_DrawWorld);
 		GET_FUTURE(R_DrawEntitiesOnList);
 		GET_FUTURE(R_DrawParticles);
-		GET_FUTURE(BIsValveGame);
+		GET_FUTURE(BUsesSDLInput);
 
 		if (oldEngine) {
 			GET_FUTURE(LoadAndDecryptHwDLL);
@@ -5378,10 +5378,10 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawParticles)
 	ORIG_R_DrawParticles();
 }
 
-HOOK_DEF_0(HwDLL, int, __cdecl, BIsValveGame)
+HOOK_DEF_0(HwDLL, int, __cdecl, BUsesSDLInput)
 {
 	if (ClientDLL::GetInstance().DoesGameDirMatch("bshift_cutsceneless"))
 		return true;
 	else
-		return ORIG_BIsValveGame();
+		return ORIG_BUsesSDLInput();
 }

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -68,7 +68,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, R_DrawWorld)
 	HOOK_DECL(void, __cdecl, R_DrawEntitiesOnList)
 	HOOK_DECL(void, __cdecl, R_DrawParticles)
-	HOOK_DECL(int, __fastcall, BIsValveGame, void *thisptr)
+	HOOK_DECL(int, __cdecl, BIsValveGame)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -68,6 +68,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, R_DrawWorld)
 	HOOK_DECL(void, __cdecl, R_DrawEntitiesOnList)
 	HOOK_DECL(void, __cdecl, R_DrawParticles)
+	HOOK_DECL(int, __fastcall, BIsValveGame, void *thisptr)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -68,7 +68,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, R_DrawWorld)
 	HOOK_DECL(void, __cdecl, R_DrawEntitiesOnList)
 	HOOK_DECL(void, __cdecl, R_DrawParticles)
-	HOOK_DECL(int, __cdecl, BIsValveGame)
+	HOOK_DECL(int, __cdecl, BUsesSDLInput)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -446,6 +446,11 @@ namespace patterns
 			"HL-SteamPipe",
 			"55 8B EC 51 A1 ?? ?? ?? ?? 85 C0 75"
 		);
+
+		PATTERNS(BIsValveGame,
+			"HL-SteamPipe",
+			"56 33 F6 8B 86 ?? ?? ?? ??"
+		);
 	}
 
 	namespace server

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -447,9 +447,9 @@ namespace patterns
 			"55 8B EC 51 A1 ?? ?? ?? ?? 85 C0 75"
 		);
 
-		PATTERNS(BIsValveGame,
+		PATTERNS(BUsesSDLInput,
 			"HL-SteamPipe",
-			"56 33 F6 8B 86"
+			"A0 ?? ?? ?? ?? 53 84 C0 0F 85"
 		);
 	}
 

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -449,7 +449,7 @@ namespace patterns
 
 		PATTERNS(BIsValveGame,
 			"HL-SteamPipe",
-			"56 33 F6 8B 86 ?? ?? ?? ??"
+			"56 33 F6 8B 86"
 		);
 	}
 


### PR DESCRIPTION
Only hooked on steam, therefore doesn't break any existing older mods. 

It's valve DLLs so just like the original game ("bshift") returns true for `BIsValveGame` it has to return true for `BIsValveGame` (aka useLibSDLInput=true) here as well otherwise mouse movement 360° doesn't work. This isn't fixed by RInput (based on Muty's test stream, where until he renamed the folder to "dod" he couldn't get mouse 360° in the mod with rinput or without.)

cc @hobokenn 