### PR TITLE
Rename bxt_ch_set_angles to bxt_set_angles to not ruin future segmented runs via sv_cheats enabled

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -2232,7 +2232,7 @@ struct HwDLL::Cmd_BXT_CH_Get_Origin_And_Angles
 		auto &hw = HwDLL::GetInstance();
 		float angles[3];
 		hw.GetViewangles(angles);
-		hw.ORIG_Con_Printf("bxt_ch_set_angles %f %f %f;", angles[0], angles[1], angles[2]);
+		hw.ORIG_Con_Printf("bxt_set_angles %f %f %f;", angles[0], angles[1], angles[2]);
 		hw.ORIG_Con_Printf("bxt_ch_set_pos %f %f %f\n", (*hw.sv_player)->v.origin[0], (*hw.sv_player)->v.origin[1],
 		                   (*hw.sv_player)->v.origin[2]);
 	}
@@ -2298,9 +2298,9 @@ struct HwDLL::Cmd_BXT_CH_Set_Origin_Offset
 	}
 };
 
-struct HwDLL::Cmd_BXT_CH_Set_Angles
+struct HwDLL::Cmd_BXT_Set_Angles
 {
-	USAGE("Usage: bxt_ch_set_angles <pitch> <yaw> [roll]\n");
+	USAGE("Usage: bxt_set_angles <pitch> <yaw> [roll]\n");
 
 	static void handler(float x, float y)
 	{
@@ -3496,10 +3496,10 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 		Cmd_BXT_CH_Set_Velocity_Angles,
 		Handler<float>,
 		Handler<float, float, float>>("bxt_ch_set_vel_angles");
-	wrapper::AddCheat<
-		Cmd_BXT_CH_Set_Angles,
+	wrapper::Add<
+		Cmd_BXT_Set_Angles,
 		Handler<float, float>,
-		Handler<float, float, float>>("bxt_ch_set_angles");
+		Handler<float, float, float>>("bxt_set_angles");
 	wrapper::Add<
 		Cmd_Multiwait,
 		Handler<>,

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -363,7 +363,7 @@ protected:
 	struct Cmd_BXT_TAS_Split;
 	struct Cmd_BXT_TAS_New;
 	struct Cmd_BXT_CH_Set_Health;
-	struct Cmd_BXT_CH_Set_Angles;
+	struct Cmd_BXT_Set_Angles;
 	struct Cmd_BXT_CH_Set_Armor;
 	struct Cmd_BXT_CH_Set_Origin;
 	struct Cmd_BXT_CH_Set_Origin_Offset;


### PR DESCRIPTION
Makes possible to avoid of usage `sv_cheats 1` in segmented runs at all.

This command has non-cheat protected counterparts such as `cl_yawspeed` and `cl_pitchspeed`, but for these cmds u have to experiment with the values to get the correct camera position, so it easier to use `bxt_set_angles` for turn. 