### PR TITLE
Fix bxt_force_fov on Linux

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3477,7 +3477,9 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_viewmodel_disable_equip);
 	RegisterCVar(CVars::bxt_viewmodel_semitransparent);
 	RegisterCVar(CVars::bxt_clear_green);
-	RegisterCVar(CVars::bxt_force_fov);
+
+	if (ORIG_R_SetFrustum && scr_fov_value)
+		RegisterCVar(CVars::bxt_force_fov);
 
 	if (ORIG_R_DrawViewModel)
 		RegisterCVar(CVars::bxt_viewmodel_fov);

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -1086,6 +1086,19 @@ void HwDLL::FindStuff()
 			EngineDevWarning("[hw dll] Could not find R_StudioRenderModel.\n");
 			EngineWarning("Changing weapon viewmodel opacity is not available.\n");
 		}
+
+		scr_fov_value = reinterpret_cast<float*>(MemUtils::GetSymbolAddress(m_Handle, "scr_fov_value"));
+		if (scr_fov_value)
+			EngineDevMsg("[hw dll] Found scr_fov_value at %p.\n", sv);
+		else
+			EngineDevWarning("[hw dll] Could not find scr_fov_value.\n");
+
+		ORIG_R_SetFrustum = reinterpret_cast<_R_SetFrustum>(MemUtils::GetSymbolAddress(m_Handle, "R_SetFrustum"));
+		if (ORIG_R_SetFrustum) {
+			EngineDevMsg("[hw dll] Found R_SetFrustum at %p.\n", ORIG_R_SetFrustum);
+		} else {
+			EngineDevWarning("[hw dll] Could not find R_SetFrustum.\n");
+		}
 	}
 	else
 	{


### PR DESCRIPTION
* just missed getting the symbols on linux

* also only register the cvar when found otherwise bxt_force_fov would crash on windows as well if scr_fov_value was nullptr on some version of the game