### PR TITLE
Opposing Force nightvision sprite toggling

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -65,6 +65,7 @@ namespace CVars
 
 	// Clientside CVars
 	CVarWrapper bxt_disable_hud("bxt_disable_hud", "0");
+	CVarWrapper bxt_disable_nightvision_sprite("bxt_disable_nightvision_sprite", "0");
 	CVarWrapper bxt_autojump_prediction("bxt_autojump_prediction", "0");
 	CVarWrapper bxt_bhopcap_prediction("bxt_bhopcap_prediction", "1");
 	CVarWrapper bxt_show_nodes("bxt_show_nodes", "0");
@@ -219,6 +220,7 @@ namespace CVars
 		&bxt_disable_autosave,
 		&bxt_disable_changelevel,
 		&bxt_disable_hud,
+		&bxt_disable_nightvision_sprite,
 		&bxt_show_custom_triggers,
 		&bxt_triggers_color,
 		&bxt_wallhack,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -178,6 +178,7 @@ namespace CVars
 
 	// Clientside CVars
 	extern CVarWrapper bxt_disable_hud;
+	extern CVarWrapper bxt_disable_nightvision_sprite;
 	extern CVarWrapper bxt_autojump_prediction;
 	extern CVarWrapper bxt_bhopcap_prediction;
 	extern CVarWrapper bxt_show_nodes;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1352,14 +1352,12 @@ HOOK_DEF_1(ClientDLL, void, __fastcall, CHudFlashlight__drawNightVision, void*, 
 {
 	if (CVars::bxt_disable_nightvision_sprite.GetBool())
 		return;
-	else
-		ORIG_CHudFlashlight__drawNightVision(thisptr);
+	ORIG_CHudFlashlight__drawNightVision(thisptr);
 }
 
 HOOK_DEF_1(ClientDLL, void, __cdecl, CHudFlashlight__drawNightVision_Linux, void*, thisptr)
 {
 	if (CVars::bxt_disable_nightvision_sprite.GetBool())
 		return;
-	else
-		ORIG_CHudFlashlight__drawNightVision_Linux(thisptr);
+	ORIG_CHudFlashlight__drawNightVision_Linux(thisptr);
 }

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -652,7 +652,7 @@ void ClientDLL::FindStuff()
 			EngineDevMsg("[client dll] Found CHudFlashlight::drawNightVision at %p (using the %s pattern).\n", ORIG_CHudFlashlight__drawNightVision, pattern->name());
 		} else {
 			ORIG_CHudFlashlight__drawNightVision_Linux = reinterpret_cast<_CHudFlashlight__drawNightVision_Linux>(MemUtils::GetSymbolAddress(m_Handle, "_ZN14CHudFlashlight15drawNightVisionEv"));
-			if (ORIG_CStudioModelRenderer__StudioRenderModel_Linux) {
+			if (ORIG_CHudFlashlight__drawNightVision_Linux) {
 				EngineDevMsg("[client dll] Found CHudFlashlight::drawNightVision [Linux] at %p.\n", ORIG_CHudFlashlight__drawNightVision_Linux);
 			} else {
 				EngineDevWarning("[client dll] Could not find HudFlashlight::drawNightVision [Linux].\n");

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -99,6 +99,11 @@ extern "C" void __cdecl _ZN20CStudioModelRenderer17StudioRenderModelEv(void *thi
 {
 	return ClientDLL::HOOKED_CStudioModelRenderer__StudioRenderModel_Linux(thisptr);
 }
+
+extern "C" void __cdecl _ZN14CHudFlashlight15drawNightVisionEv(void *thisptr)
+{
+	return ClientDLL::HOOKED_CHudFlashlight__drawNightVision_Linux(thisptr);
+}
 #endif
 
 void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept)
@@ -147,7 +152,8 @@ void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* m
 			ORIG_VectorTransform, HOOKED_VectorTransform,
 			ORIG_CStudioModelRenderer__StudioSetupBones, HOOKED_CStudioModelRenderer__StudioSetupBones,
 			ORIG_CL_IsThirdPerson, HOOKED_CL_IsThirdPerson,
-			ORIG_CStudioModelRenderer__StudioRenderModel, HOOKED_CStudioModelRenderer__StudioRenderModel);
+			ORIG_CStudioModelRenderer__StudioRenderModel, HOOKED_CStudioModelRenderer__StudioRenderModel,
+			ORIG_CHudFlashlight__drawNightVision, HOOKED_CHudFlashlight__drawNightVision);
 	}
 
 	// HACK: on Windows we don't get a LoadLibrary for SDL2, so when starting using the injector
@@ -180,7 +186,8 @@ void ClientDLL::Unhook()
 			ORIG_VectorTransform,
 			ORIG_CStudioModelRenderer__StudioSetupBones,
 			ORIG_CL_IsThirdPerson,
-			ORIG_CStudioModelRenderer__StudioRenderModel);
+			ORIG_CStudioModelRenderer__StudioRenderModel,
+			ORIG_CHudFlashlight__drawNightVision);
 	}
 
 	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_Init));
@@ -215,6 +222,8 @@ void ClientDLL::Clear()
 	ORIG_CStudioModelRenderer__StudioSetupBones_Linux = nullptr;
 	ORIG_CStudioModelRenderer__StudioRenderModel = nullptr;
 	ORIG_CStudioModelRenderer__StudioRenderModel_Linux = nullptr;
+	ORIG_CHudFlashlight__drawNightVision = nullptr;
+	ORIG_CHudFlashlight__drawNightVision_Linux = nullptr;
 	ORIG_V_CalcRefdef = nullptr;
 	ORIG_HUD_Init = nullptr;
 	ORIG_HUD_VidInit = nullptr;
@@ -373,6 +382,9 @@ void ClientDLL::FindStuff()
 	auto fCStudioModelRenderer__StudioRenderModel = FindAsync(
 		ORIG_CStudioModelRenderer__StudioRenderModel,
 		patterns::client::CStudioModelRenderer__StudioRenderModel);
+	auto fCHudFlashlight__drawNightVision = FindAsync(
+		ORIG_CHudFlashlight__drawNightVision,
+		patterns::client::CHudFlashlight__drawNightVision);
 
 	ORIG_PM_PlayerMove = reinterpret_cast<_PM_PlayerMove>(MemUtils::GetSymbolAddress(m_Handle, "PM_PlayerMove")); // For Linux.
 	ORIG_PM_ClipVelocity = reinterpret_cast<_PM_ClipVelocity>(MemUtils::GetSymbolAddress(m_Handle, "PM_ClipVelocity")); // For Linux.
@@ -633,6 +645,21 @@ void ClientDLL::FindStuff()
 			}
 		}
 	}
+
+	{
+		auto pattern = fCHudFlashlight__drawNightVision.get();
+		if (ORIG_CHudFlashlight__drawNightVision) {
+			EngineDevMsg("[client dll] Found CHudFlashlight::drawNightVision at %p (using the %s pattern).\n", ORIG_CHudFlashlight__drawNightVision, pattern->name());
+		} else {
+			ORIG_CHudFlashlight__drawNightVision_Linux = reinterpret_cast<_CHudFlashlight__drawNightVision_Linux>(MemUtils::GetSymbolAddress(m_Handle, "_ZN14CHudFlashlight15drawNightVisionEv"));
+			if (ORIG_CStudioModelRenderer__StudioRenderModel_Linux) {
+				EngineDevMsg("[client dll] Found CHudFlashlight::drawNightVision [Linux] at %p.\n", ORIG_CHudFlashlight__drawNightVision_Linux);
+			} else {
+				EngineDevWarning("[client dll] Could not find HudFlashlight::drawNightVision [Linux].\n");
+				EngineWarning("[client dll] Disabling Opposing Force nightvision sprite is unavailable.\n");
+			}
+		}
+	}
 }
 
 bool ClientDLL::FindHUDFunctions()
@@ -782,6 +809,10 @@ void ClientDLL::RegisterCVarsAndCommands()
 
 	if (ORIG_CL_IsThirdPerson) {
 		REG(bxt_show_player_in_hltv);
+	}
+
+	if (ORIG_CHudFlashlight__drawNightVision_Linux || ORIG_CHudFlashlight__drawNightVision) {
+		REG(bxt_disable_nightvision_sprite);
 	}
 	#undef REG
 }
@@ -1315,4 +1346,20 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, CStudioModelRenderer__StudioRenderModel_Lin
 	}
 
 	ORIG_CStudioModelRenderer__StudioRenderModel_Linux(thisptr);
+}
+
+HOOK_DEF_1(ClientDLL, void, __fastcall, CHudFlashlight__drawNightVision, void*, thisptr)
+{
+	if (CVars::bxt_disable_nightvision_sprite.GetBool())
+		return;
+	else
+		ORIG_CHudFlashlight__drawNightVision(thisptr);
+}
+
+HOOK_DEF_1(ClientDLL, void, __cdecl, CHudFlashlight__drawNightVision_Linux, void*, thisptr)
+{
+	if (CVars::bxt_disable_nightvision_sprite.GetBool())
+		return;
+	else
+		ORIG_CHudFlashlight__drawNightVision_Linux(thisptr);
 }

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -33,6 +33,8 @@ class ClientDLL : public IHookableNameFilter
 	HOOK_DECL(int, __cdecl, CL_IsThirdPerson)
 	HOOK_DECL(void, __fastcall, CStudioModelRenderer__StudioRenderModel, void* thisptr)
 	HOOK_DECL(void, __cdecl, CStudioModelRenderer__StudioRenderModel_Linux, void* thisptr)
+	HOOK_DECL(void, __fastcall, CHudFlashlight__drawNightVision, void* thisptr)
+	HOOK_DECL(void, __cdecl, CHudFlashlight__drawNightVision_Linux, void* thisptr)
 
 public:
 	static ClientDLL& GetInstance()

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -741,6 +741,11 @@ namespace patterns
 			"AoMDC",
 			"55 8B EC 83 EC 44 53 56 57 89 4D ?? FF 15 ?? ?? ?? ?? 6A 00"
 		);
+
+		PATTERNS(CHudFlashlight__drawNightVision,
+			"Op4-WON",
+			"83 EC 18 53 55 56 8B F1 57"
+		);
 	}
 
 	namespace shared


### PR DESCRIPTION
QoL: currently runners replace the nightvision sprite with an empty transparent one to get this effect.

![image](https://user-images.githubusercontent.com/5108747/157105992-9e83677c-62bc-422b-bb0b-57929891bf89.png)
![image](https://user-images.githubusercontent.com/5108747/157105996-cf9ac38e-55ab-4332-adf7-d2339b52b205.png)
