### PR TITLE
Don't stop timer on crash

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -25,6 +25,7 @@ namespace CustomHud
 	static bool receivedAccurateInfo = false;
 	static playerinfo player;
 	bool countingTime = false;
+	bool invalidRun = false;
 	int hours = 0, minutes = 0, seconds = 0;
 	double timeRemainder = 0.0;
 	int frames = 0;
@@ -338,6 +339,14 @@ namespace CustomHud
 		return DrawNumber(number, x, y, hudColor[0], hudColor[1], hudColor[2], fieldMinWidth);
 	}
 
+	static inline int DrawNumberTimer(int number, int x, int y, int fieldMinWidth = 1)
+	{
+		if (invalidRun)
+			return DrawNumber(number, x, y, 240, 0, 0, fieldMinWidth);
+		else
+			return DrawNumber(number, x, y, hudColor[0], hudColor[1], hudColor[2], fieldMinWidth);
+	}
+
 	static void DrawDecimalSeparator(int x, int y, int r, int g, int b)
 	{
 		x += (NumberWidth - 6) / 2;
@@ -347,7 +356,10 @@ namespace CustomHud
 
 	static void DrawDecimalSeparator(int x, int y)
 	{
-		return DrawDecimalSeparator(x, y, hudColor[0], hudColor[1], hudColor[2]);
+		if (invalidRun)
+			return DrawDecimalSeparator(x, y, 240, 0, 0);
+		else
+			return DrawDecimalSeparator(x, y, hudColor[0], hudColor[1], hudColor[2]);
 	}
 
 	static void DrawColon(int x, int y, int r, int g, int b)
@@ -360,7 +372,10 @@ namespace CustomHud
 
 	static void DrawColon(int x, int y)
 	{
-		return DrawColon(x, y, hudColor[0], hudColor[1], hudColor[2]);
+		if (invalidRun)
+			return DrawColon(x, y, 240, 0, 0);
+		else
+			return DrawColon(x, y, hudColor[0], hudColor[1], hudColor[2]);
 	}
 
 	static void GetPosition(const CVarWrapper& Offset, const CVarWrapper& Anchor, int* x, int* y, int rx = 0, int ry = 0)
@@ -632,9 +647,12 @@ namespace CustomHud
 			int x, y;
 			GetPosition(CVars::bxt_hud_timer_offset, CVars::bxt_hud_timer_anchor, &x, &y, 0, 0);
 
+			if (invalidRun)
+				DrawMultilineString(x, y + NumberHeight, "Invalid run", 1.0f, 0.0f, 0.0f);
+
 			if (hours)
 			{
-				x = DrawNumber(hours, x, y);
+				x = DrawNumberTimer(hours, x, y);
 				DrawColon(x, y);
 				x += NumberWidth;
 			}
@@ -642,18 +660,18 @@ namespace CustomHud
 			if (hours || minutes)
 			{
 				int fieldMinWidth = (hours && minutes < 10) ? 2 : 1;
-				x = DrawNumber(minutes, x, y, fieldMinWidth);
+				x = DrawNumberTimer(minutes, x, y, fieldMinWidth);
 				DrawColon(x, y);
 				x += NumberWidth;
 			}
 
 			int fieldMinWidth = ((hours || minutes) && seconds < 10) ? 2 : 1;
-			x = DrawNumber(seconds, x, y, fieldMinWidth);
+			x = DrawNumberTimer(seconds, x, y, fieldMinWidth);
 
 			DrawDecimalSeparator(x, y);
 			x += NumberWidth;
 
-			DrawNumber(static_cast<int>(timeRemainder * 1000), x, y, 3);
+			DrawNumberTimer(static_cast<int>(timeRemainder * 1000), x, y, 3);
 		}
 	}
 
@@ -1513,6 +1531,7 @@ namespace CustomHud
 	{
 		Interprocess::WriteTimerReset(GetTime());
 		countingTime = false;
+		invalidRun = false;
 		hours = minutes = seconds = 0;
 		timeRemainder = 0.0;
 		frames = 0;
@@ -1525,6 +1544,13 @@ namespace CustomHud
 			Interprocess::WriteTimerStart(GetTime());
 
 		countingTime = counting;
+	}
+
+	void SetInvalidRun(bool invalidated)
+	{
+		// Only set as invalid, if the timer is actually running
+		if (countingTime)
+			invalidRun = invalidated;
 	}
 
 	void SendTimeUpdate() {

--- a/BunnymodXT/hud_custom.hpp
+++ b/BunnymodXT/hud_custom.hpp
@@ -24,6 +24,7 @@ namespace CustomHud
 	void TimePassed(double time);
 	void ResetTime();
 	void SetCountingTime(bool counting);
+	void SetInvalidRun(bool invalidated);
 	void SendTimeUpdate();
 	void SaveTimeToDemo();
 	Interprocess::Time GetTime();

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -2442,6 +2442,7 @@ struct HwDLL::Cmd_BXT_Timer_Reset
 	static void handler()
 	{
 		CustomHud::SaveTimeToDemo();
+		CustomHud::SetInvalidRun(false);
 		return CustomHud::ResetTime();
 	}
 };

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1923,14 +1923,18 @@ HOOK_DEF_4(ServerDLL, void, __fastcall, CPushable__Move, void*, thisptr, int, ed
 
 void ServerDLL::DoWouldCrashMessage()
 {
-	char command[] = "say The game would have crashed. BXT prevented the crash and the timer was stopped. This run is no longer valid.\n";
+	char command[] = "say The game would have crashed. BXT prevented the crash, however this run is no longer valid.\n";
 	// We send a say message from the ServerDLL so that we have the notice in the demo.
 	pEngfuncs->pfnServerCommand(command);
 	// Console
-	pEngfuncs->pfnServerPrint("[BXT] The game would have crashed. BXT prevented the crash and the timer was stopped. This run is no longer valid.\n");
+	pEngfuncs->pfnServerPrint("[BXT] The game would have crashed. BXT prevented the crash, however this run is no longer valid.\n");
 
 	CustomHud::SaveTimeToDemo();
-	CustomHud::SetCountingTime(false);
+	CustomHud::SetInvalidRun(true);
+
+	// Some people might be running with LiveSplit only and hud_saytext CAN be 0, enable timer for those players, so they know
+	if (!CVars::bxt_hud_timer.GetBool())
+		HwDLL::GetInstance().SetCVarValue(CVars::bxt_hud_timer, "1");
 }
 
 HOOK_DEF_6(ServerDLL, int, __fastcall, CBasePlayer__TakeDamage, void*, thisptr, int, edx, entvars_t*, pevInflictor, entvars_t*, pevAttacker, float, flDamage, int, bitsDamageType)


### PR DESCRIPTION
As per Kananga's and @mxpph idea/request:

Kananga hosts HL1 races and he uses people's in-game timer on their respective streams (because of stream lag etc.) for comparing the final time to see "who won". During the last HL1 race he hosted a person crashed on hornet (bxt prevented) and Kananga wants to give people who crash a chance, so he had to start his timer again, but he did that late and they had to manually add the time to his timer, hence the suggested idea of a racemode was born. 

I'd link a timestamp'd video, but he didn't highlight it atm.

The run is still invalid, but people in the race will run with `bxt_racemode_on_crash 1` in order to not lose the timer for Kananga to use.