### PR TITLE
Added bxt_hud_game_color and bxt_hud_game_alpha

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -89,6 +89,8 @@ namespace CVars
 	CVarWrapper bxt_show_player_in_hltv("bxt_show_player_in_hltv", "0");
 	CVarWrapper bxt_hud("bxt_hud", "1");
 	CVarWrapper bxt_hud_color("bxt_hud_color", "");
+	CVarWrapper bxt_hud_game_color("bxt_hud_game_color", "");
+	CVarWrapper bxt_hud_game_alpha("bxt_hud_game_alpha", "0");
 	CVarWrapper bxt_hud_precision("bxt_hud_precision", "6");
 	CVarWrapper bxt_hud_quickgauss("bxt_hud_quickgauss", "0");
 	CVarWrapper bxt_hud_quickgauss_offset("bxt_hud_quickgauss_offset", "");
@@ -243,6 +245,8 @@ namespace CVars
 		&bxt_show_player_in_hltv,
 		&bxt_hud,
 		&bxt_hud_color,
+		&bxt_hud_game_color,
+		&bxt_hud_game_alpha,
 		&bxt_hud_precision,
 		&bxt_hud_quickgauss,
 		&bxt_hud_quickgauss_offset,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -202,6 +202,8 @@ namespace CVars
 	extern CVarWrapper bxt_show_player_in_hltv;
 	extern CVarWrapper bxt_hud;
 	extern CVarWrapper bxt_hud_color;
+	extern CVarWrapper bxt_hud_game_color;
+	extern CVarWrapper bxt_hud_game_alpha;
 	extern CVarWrapper bxt_hud_precision;
 	extern CVarWrapper bxt_hud_quickgauss;
 	extern CVarWrapper bxt_hud_quickgauss_offset;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1086,16 +1086,13 @@ HOOK_DEF_0(ClientDLL, void, __cdecl, HUD_Reset)
 
 HOOK_DEF_2(ClientDLL, void, __cdecl, HUD_Redraw, float, time, int, intermission)
 {
-	if (!CVars::bxt_hud_game_color.IsEmpty()) {
+	custom_hud_color_set = false;
+
+	if (sscanf(CVars::bxt_hud_game_color.GetString().c_str(), "%hhu %hhu %hhu", &custom_r, &custom_g, &custom_b) == 3)
 		custom_hud_color_set = true;
-		std::istringstream ss(CVars::bxt_hud_game_color.GetString());
-		ss >> custom_r >> custom_g >> custom_b;
-	}
 
 	if (!CVars::bxt_disable_hud.GetBool())
 		ORIG_HUD_Redraw(time, intermission);
-
-	custom_hud_color_set = false;
 
 	CustomHud::Draw(time);
 }
@@ -1407,8 +1404,8 @@ HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int
 		*b = custom_b;
 	}
 
-	if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255)
-		a = CVars::bxt_hud_game_alpha.GetInt();
+	if (CVars::bxt_hud_game_alpha.GetFloat() > 0 && CVars::bxt_hud_game_alpha.GetFloat() <= 1)
+		a = static_cast<int>(CVars::bxt_hud_game_alpha.GetFloat() * 255);
 
 	ORIG_ScaleColors(r, g, b, a);
 }

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1404,8 +1404,8 @@ HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int
 		*b = custom_b;
 	}
 
-	if (CVars::bxt_hud_game_alpha.GetFloat() > 0 && CVars::bxt_hud_game_alpha.GetFloat() <= 1)
-		a = static_cast<int>(CVars::bxt_hud_game_alpha.GetFloat() * 255);
+	if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255)
+		a = CVars::bxt_hud_game_alpha.GetInt();
 
 	ORIG_ScaleColors(r, g, b, a);
 }

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1086,8 +1086,16 @@ HOOK_DEF_0(ClientDLL, void, __cdecl, HUD_Reset)
 
 HOOK_DEF_2(ClientDLL, void, __cdecl, HUD_Redraw, float, time, int, intermission)
 {
+	if (!CVars::bxt_hud_game_color.IsEmpty()) {
+		custom_hud_color_set = true;
+		std::istringstream ss(CVars::bxt_hud_game_color.GetString());
+		ss >> custom_r >> custom_g >> custom_b;
+	}
+
 	if (!CVars::bxt_disable_hud.GetBool())
 		ORIG_HUD_Redraw(time, intermission);
+
+	custom_hud_color_set = false;
 
 	CustomHud::Draw(time);
 }
@@ -1393,11 +1401,7 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, CHudFlashlight__drawNightVision_Linux, void
 
 HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int, a)
 {
-	if (!CVars::bxt_hud_game_color.IsEmpty()) {
-		unsigned custom_r = 0, custom_g = 0, custom_b = 0;
-		std::istringstream ss(CVars::bxt_hud_game_color.GetString());
-		ss >> custom_r >> custom_g >> custom_b;
-
+	if (custom_hud_color_set) {
 		*r = custom_r;
 		*g = custom_g;
 		*b = custom_b;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -104,6 +104,11 @@ extern "C" void __cdecl _ZN14CHudFlashlight15drawNightVisionEv(void *thisptr)
 {
 	return ClientDLL::HOOKED_CHudFlashlight__drawNightVision_Linux(thisptr);
 }
+
+extern "C" void __cdecl _Z11ScaleColorsRiS_S_i(int* r, int* g, int* b, int a)
+{
+	return ClientDLL::HOOKED_ScaleColors(r, g, b, a);
+}
 #endif
 
 void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept)
@@ -153,7 +158,8 @@ void ClientDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* m
 			ORIG_CStudioModelRenderer__StudioSetupBones, HOOKED_CStudioModelRenderer__StudioSetupBones,
 			ORIG_CL_IsThirdPerson, HOOKED_CL_IsThirdPerson,
 			ORIG_CStudioModelRenderer__StudioRenderModel, HOOKED_CStudioModelRenderer__StudioRenderModel,
-			ORIG_CHudFlashlight__drawNightVision, HOOKED_CHudFlashlight__drawNightVision);
+			ORIG_CHudFlashlight__drawNightVision, HOOKED_CHudFlashlight__drawNightVision,
+			ORIG_ScaleColors, HOOKED_ScaleColors);
 	}
 
 	// HACK: on Windows we don't get a LoadLibrary for SDL2, so when starting using the injector
@@ -187,7 +193,8 @@ void ClientDLL::Unhook()
 			ORIG_CStudioModelRenderer__StudioSetupBones,
 			ORIG_CL_IsThirdPerson,
 			ORIG_CStudioModelRenderer__StudioRenderModel,
-			ORIG_CHudFlashlight__drawNightVision);
+			ORIG_CHudFlashlight__drawNightVision,
+			ORIG_ScaleColors);
 	}
 
 	MemUtils::RemoveSymbolLookupHook(m_Handle, reinterpret_cast<void*>(ORIG_HUD_Init));
@@ -238,6 +245,7 @@ void ClientDLL::Clear()
 	ORIG_IN_ActivateMouse = nullptr;
 	ORIG_IN_DeactivateMouse = nullptr;
 	ORIG_CL_IsThirdPerson = nullptr;
+	ORIG_ScaleColors = nullptr;
 	ppmove = nullptr;
 	offOldbuttons = 0;
 	offOnground = 0;
@@ -385,6 +393,7 @@ void ClientDLL::FindStuff()
 	auto fCHudFlashlight__drawNightVision = FindAsync(
 		ORIG_CHudFlashlight__drawNightVision,
 		patterns::client::CHudFlashlight__drawNightVision);
+	auto fScaleColors = FindAsync(ORIG_ScaleColors, patterns::client::ScaleColors);
 
 	ORIG_PM_PlayerMove = reinterpret_cast<_PM_PlayerMove>(MemUtils::GetSymbolAddress(m_Handle, "PM_PlayerMove")); // For Linux.
 	ORIG_PM_ClipVelocity = reinterpret_cast<_PM_ClipVelocity>(MemUtils::GetSymbolAddress(m_Handle, "PM_ClipVelocity")); // For Linux.
@@ -660,6 +669,21 @@ void ClientDLL::FindStuff()
 			}
 		}
 	}
+
+	{
+		auto pattern = fScaleColors.get();
+		if (ORIG_ScaleColors) {
+			EngineDevMsg("[client dll] Found ScaleColors at %p (using the %s pattern).\n", ORIG_ScaleColors, pattern->name());
+		} else {
+			ORIG_ScaleColors = reinterpret_cast<_ScaleColors>(MemUtils::GetSymbolAddress(m_Handle, "_Z11ScaleColorsRiS_S_i"));
+			if (ORIG_ScaleColors) {
+				EngineDevMsg("[client dll] Found ScaleColors at %p.\n", ORIG_ScaleColors);
+			} else {
+				EngineDevWarning("[client dll] Could not find ScaleColors.\n");
+				EngineWarning("[client dll] Changing HUD color and alpha is not available.\n");
+			}
+		}
+	}
 }
 
 bool ClientDLL::FindHUDFunctions()
@@ -813,6 +837,11 @@ void ClientDLL::RegisterCVarsAndCommands()
 
 	if (ORIG_CHudFlashlight__drawNightVision_Linux || ORIG_CHudFlashlight__drawNightVision) {
 		REG(bxt_disable_nightvision_sprite);
+	}
+
+	if (ORIG_ScaleColors) {
+		REG(bxt_hud_game_color);
+		REG(bxt_hud_game_alpha);
 	}
 	#undef REG
 }
@@ -1360,4 +1389,22 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, CHudFlashlight__drawNightVision_Linux, void
 	if (CVars::bxt_disable_nightvision_sprite.GetBool())
 		return;
 	ORIG_CHudFlashlight__drawNightVision_Linux(thisptr);
+}
+
+HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int, a)
+{
+	if (!CVars::bxt_hud_game_color.IsEmpty()) {
+		unsigned custom_r = 0, custom_g = 0, custom_b = 0;
+		std::istringstream ss(CVars::bxt_hud_game_color.GetString());
+		ss >> custom_r >> custom_g >> custom_b;
+
+		*r = custom_r;
+		*g = custom_g;
+		*b = custom_b;
+	}
+
+	if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255)
+		a = CVars::bxt_hud_game_alpha.GetInt();
+
+	ORIG_ScaleColors(r, g, b, a);
 }

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -35,6 +35,7 @@ class ClientDLL : public IHookableNameFilter
 	HOOK_DECL(void, __cdecl, CStudioModelRenderer__StudioRenderModel_Linux, void* thisptr)
 	HOOK_DECL(void, __fastcall, CHudFlashlight__drawNightVision, void* thisptr)
 	HOOK_DECL(void, __cdecl, CHudFlashlight__drawNightVision_Linux, void* thisptr)
+	HOOK_DECL(void, __cdecl, ScaleColors, int* r, int* g, int* b, int a)
 
 public:
 	static ClientDLL& GetInstance()

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -64,6 +64,10 @@ public:
 
 	bool DoesGameDirMatch(const char *game);
 
+	unsigned custom_r = 0, custom_g = 0, custom_b = 0;
+
+	bool custom_hud_color_set = false;
+
 	unsigned short last_buttons;
 
 	// When set to false, the mouse won't move the camera.

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -64,8 +64,7 @@ public:
 
 	bool DoesGameDirMatch(const char *game);
 
-	unsigned custom_r = 0, custom_g = 0, custom_b = 0;
-
+	unsigned char custom_r, custom_g, custom_b;
 	bool custom_hud_color_set = false;
 
 	unsigned short last_buttons;

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -753,7 +753,13 @@ namespace patterns
 
 		PATTERNS(ScaleColors,
 			"HL-SteamPipe",
-			"DB 44 24 ?? 56 8B 74 24 ?? D8 0D"
+			"DB 44 24 ?? 56 8B 74 24 ?? D8 0D",
+			"Echoes",
+			"55 8B EC 51 DB 45",
+			"AoMDC",
+			"55 8B EC 83 EC 44 53 56 57 DB 45",
+			"Halfquake-Trilogy",
+			"55 8B EC 66 0F 6E 4D"
 		);
 	}
 

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -750,6 +750,11 @@ namespace patterns
 			"Op4-WON",
 			"83 EC 18 53 55 56 8B F1 57"
 		);
+
+		PATTERNS(ScaleColors,
+			"HL-SteamPipe",
+			"DB 44 24 ?? 56 8B 74 24 ?? D8 0D"
+		);
 	}
 
 	namespace shared


### PR DESCRIPTION
Allow to change in-game HUD color and alpha.

# Confirmation from @chinese-soup that it works on Linux:

![0](https://user-images.githubusercontent.com/58108407/158706942-f9a8f6c3-bfe0-4e67-a97e-4479bbc7c0c6.PNG)

# HL1 (255 alpha, "255 100 255" rgb):

![изображение](https://user-images.githubusercontent.com/58108407/158710053-67a9bacf-c32a-4ec0-9df2-0cfe21c45322.png)

# OP4 (255 alpha, "0 255 255" rgb):

![изображение](https://user-images.githubusercontent.com/58108407/158706708-37b38018-7d44-42da-853f-90342ecb60c1.png)

# CSCZDS ("255 255 255" rgb):

![изображение](https://user-images.githubusercontent.com/58108407/158706775-4be060d8-5d36-4c49-aa23-928bf87eedcb.png)
