### PR TITLE
entity_info: allow to see the exact origin of the brush entities

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -780,7 +780,7 @@ namespace CustomHud
 					// Borrowed from https://github.com/SNMetamorph/goldsrc-monitor/blob/08c368e246d09996b2d85e4367d4d8cc1e507712/sources/library/displaymode_entityreport.cpp#L45
 					Vector origin;
 
-					if (strstr(classname, "func_") != NULL)
+					if (ent->v.solid == SOLID_BSP || ent->v.movetype == MOVETYPE_PUSHSTEP)
 						origin = ent->v.origin + ((ent->v.mins + ent->v.maxs) / 2.f);
 					else
 						origin = ent->v.origin;

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -773,12 +773,17 @@ namespace CustomHud
 					}
 				}
 
-				// Borrowed from https://github.com/SNMetamorph/goldsrc-monitor/blob/08c368e246d09996b2d85e4367d4d8cc1e507712/sources/library/displaymode_entityreport.cpp#L45-L48
-				const Vector origin = ent->v.origin + ((ent->v.mins + ent->v.maxs) / 2.f);
-
 				if (CVars::bxt_hud_entity_info.GetInt() == 2)
 				{
 					out << "Yaw: " << ent->v.angles[1] << '\n';
+
+					// Borrowed from https://github.com/SNMetamorph/goldsrc-monitor/blob/08c368e246d09996b2d85e4367d4d8cc1e507712/sources/library/displaymode_entityreport.cpp#L45
+					Vector origin;
+
+					if (strstr(classname, "func_") != NULL)
+						origin = ent->v.origin + ((ent->v.mins + ent->v.maxs) / 2.f);
+					else
+						origin = ent->v.origin;
 
 					out << "X: " << origin.x << '\n';
 					out << "Y: " << origin.y << '\n';

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -773,13 +773,16 @@ namespace CustomHud
 					}
 				}
 
+				// Borrowed from https://github.com/SNMetamorph/goldsrc-monitor/blob/08c368e246d09996b2d85e4367d4d8cc1e507712/sources/library/displaymode_entityreport.cpp#L45-L48
+				const Vector origin = ent->v.origin + ((ent->v.mins + ent->v.maxs) / 2.f);
+
 				if (CVars::bxt_hud_entity_info.GetInt() == 2)
 				{
 					out << "Yaw: " << ent->v.angles[1] << '\n';
 
-					out << "X: " << ent->v.origin.x << '\n';
-					out << "Y: " << ent->v.origin.y << '\n';
-					out << "Z: " << ent->v.origin.z << '\n';
+					out << "X: " << origin.x << '\n';
+					out << "Y: " << origin.y << '\n';
+					out << "Z: " << origin.z << '\n';
 
 					out << "X Vel: " << ent->v.velocity.x << '\n';
 					out << "Y Vel: " << ent->v.velocity.y << '\n';


### PR DESCRIPTION
Old behaviour:

![изображение](https://user-images.githubusercontent.com/58108407/159719067-1abcd103-1d09-4a4a-9c5c-fbb280cdc695.png)

New behaviour:

![изображение](https://user-images.githubusercontent.com/58108407/159719038-4d450dca-5a0b-4633-b727-207dd7774fa1.png)
