### PR TITLE
entity_info: check if door has a flag for usable

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -766,11 +766,16 @@ namespace CustomHud
 
 				if (strstr(classname, "func_door") != NULL)
 				{
-					if (ent->v.spawnflags & 512) { // https://github.com/ValveSoftware/halflife/blob/master/dlls/doors.h#L28
+					// https://github.com/ValveSoftware/halflife/blob/master/dlls/doors.h#L27-L28
+					if (ent->v.spawnflags & 256)
+						out << "Usable: Yes" << '\n';
+					else
+						out << "Usable: No" << '\n';
+
+					if (ent->v.spawnflags & 512)
 						out << "Monsters: Can't open" << '\n';
-					} else {
+					else
 						out << "Monsters: Can open" << '\n';
-					}
 				}
 
 				if (CVars::bxt_hud_entity_info.GetInt() == 2)

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -857,7 +857,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_selfgauss.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_selfgauss_offset, CVars::bxt_hud_selfgauss_anchor, &x, &y, -200, (si.iCharHeight * 29) + 3);
+			GetPosition(CVars::bxt_hud_selfgauss_offset, CVars::bxt_hud_selfgauss_anchor, &x, &y, -200, (si.iCharHeight * 30) + 3);
 
 			bool selfgaussable;
 			int hitGroup = 0; // It's always initialized if selfgaussable is set to true, but GCC issues a warning anyway.
@@ -915,7 +915,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_armor.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_armor_offset, CVars::bxt_hud_armor_anchor, &x, &y, -200, (si.iCharHeight * 32) + 3);
+			GetPosition(CVars::bxt_hud_armor_offset, CVars::bxt_hud_armor_anchor, &x, &y, -200, (si.iCharHeight * 33) + 3);
 
 			std::ostringstream out;
 			out.setf(std::ios::fixed);
@@ -933,7 +933,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_nihilanth.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 33) + 3);
+			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 34) + 3);
 
 			std::ostringstream out;
 			out << "Nihilanth:\n";
@@ -967,7 +967,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_gonarch.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 40) + 3);
+			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 41) + 3);
 
 			std::ostringstream out;
 			out << "Gonarch:\n";


### PR DESCRIPTION
That spawnflag prevent door from opening by touch, but it allow for `+use` or being triggered.

https://user-images.githubusercontent.com/58108407/161095705-2c30f047-2762-43ef-8f81-339f72f2ddcf.mp4

The advantage over `bxt_hud_useables 1` for that case that in different mods, incorrect `offFuncObjectCaps` might crash game as like it been in #141 issue. 