### PR TITLE
ammohistory: replaced engine method for custom colors to clientside for hud fading

### DIFF
--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -33,6 +33,9 @@ class ClientDLL : public IHookableNameFilter
 	HOOK_DECL(int, __cdecl, CL_IsThirdPerson)
 	HOOK_DECL(void, __fastcall, CStudioModelRenderer__StudioRenderModel, void* thisptr)
 	HOOK_DECL(void, __cdecl, CStudioModelRenderer__StudioRenderModel_Linux, void* thisptr)
+	HOOK_DECL(void, __cdecl, ScaleColors, int* r, int* g, int* b, int a)
+	HOOK_DECL(int, __fastcall, HistoryResource__DrawAmmoHistory, void *thisptr, int edx, float flTime)
+	HOOK_DECL(int, __cdecl, HistoryResource__DrawAmmoHistory_Linux, void *thisptr, float flTime)
 	HOOK_DECL(void, __fastcall, CHudFlashlight__drawNightVision, void* thisptr)
 	HOOK_DECL(void, __cdecl, CHudFlashlight__drawNightVision_Linux, void* thisptr)
 	HOOK_DECL(bool, __fastcall, CHud__DrawHudNightVision, void *thisptr, int edx, float flTime)
@@ -68,6 +71,8 @@ public:
 	unsigned char custom_r, custom_g, custom_b;
 	bool custom_hud_color_set = false;
 	bool bxt_hud_color_set = false;
+
+	bool insideDrawAmmoHistory = false;
 
 	unsigned short last_buttons;
 

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -5754,7 +5754,7 @@ HOOK_DEF_4(HwDLL, void, __cdecl, SPR_Set, HSPRITE_HL, hSprite, int, r, int, g, i
 {
 	auto& cl = ClientDLL::GetInstance();
 
-	if (cl.custom_hud_color_set && !cl.bxt_hud_color_set && !insideDrawCrosshair)
+	if (cl.custom_hud_color_set && !cl.bxt_hud_color_set && !insideDrawCrosshair && !cl.insideDrawAmmoHistory)
 	{
 		r = cl.custom_r;
 		g = cl.custom_g;

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -800,6 +800,32 @@ namespace patterns
 			"CSCZDS",
 			"56 8B F1 8A 86 ?? ?? ?? ?? 84 C0 75 ?? 32 C0 5E C2 04 00 8B 46 ?? 85 C0 75 ?? 68 ?? ?? ?? ?? E8 ?? ?? ?? ?? 83 C4 04 89 46 ?? 8B 46 ?? 6A 64"
 		);
+
+		PATTERNS(ScaleColors,
+			"HL-SteamPipe",
+			"DB 44 24 ?? 56 8B 74 24 ?? D8 0D",
+			"Echoes",
+			"55 8B EC 51 DB 45",
+			"AoMDC",
+			"55 8B EC 83 EC 44 53 56 57 DB 45",
+			"Halfquake-Trilogy",
+			"55 8B EC 66 0F 6E 4D"
+		);
+
+		PATTERNS(HistoryResource__DrawAmmoHistory,
+			"HL-Steampipe",
+			"83 EC 50 53 55",
+			"CSCZDS",
+			"83 EC 50 53 ?? ?? 55",
+			"Echoes",
+			"55 8B EC 81 EC 88 00 00 00 89 4D",
+			"AoMDC",
+			"55 8B EC 81 EC C8 00 00 00 53 56 57 89 4D ?? C7 45 ?? 00 00 00 00",
+			"Halfquake-Trilogy",
+			"55 8B EC 83 EC 58 A1 ?? ?? ?? ?? 33 C5 89 45 ?? 53 56 8B F1",
+			"TWHL-Tower-2",
+			"55 8B EC 83 EC 54 83 65 ?? 00"
+		);
 	}
 
 	namespace shared


### PR DESCRIPTION
Generally, engine method for changing colors is a nicely than clientside, but when it comes to HUD fading, it is bad - since alpha is being forced to 255 in `SPR_Set`.

Ammohistory is single HUD element which makes notice that issue, all other HUDs is fine to change at engineside.