### PR TITLE
Added bxt_hud_game_alpha_max_clientside

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -90,6 +90,7 @@ namespace CVars
 	CVarWrapper bxt_unlock_camera_during_pause("bxt_unlock_camera_during_pause", "0");
 	CVarWrapper bxt_hud("bxt_hud", "1");
 	CVarWrapper bxt_hud_color("bxt_hud_color", "");
+	CVarWrapper bxt_hud_game_alpha_max_clientside("bxt_hud_game_alpha_max_clientside", "0");
 	CVarWrapper bxt_hud_precision("bxt_hud_precision", "6");
 	CVarWrapper bxt_hud_quickgauss("bxt_hud_quickgauss", "0");
 	CVarWrapper bxt_hud_quickgauss_offset("bxt_hud_quickgauss_offset", "");
@@ -250,6 +251,7 @@ namespace CVars
 		&bxt_unlock_camera_during_pause,
 		&bxt_hud,
 		&bxt_hud_color,
+		&bxt_hud_game_alpha_max_clientside,
 		&bxt_hud_precision,
 		&bxt_hud_quickgauss,
 		&bxt_hud_quickgauss_offset,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -203,6 +203,7 @@ namespace CVars
 	extern CVarWrapper bxt_unlock_camera_during_pause;
 	extern CVarWrapper bxt_hud;
 	extern CVarWrapper bxt_hud_color;
+	extern CVarWrapper bxt_hud_game_alpha_max_clientside;
 	extern CVarWrapper bxt_hud_precision;
 	extern CVarWrapper bxt_hud_quickgauss;
 	extern CVarWrapper bxt_hud_quickgauss_offset;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -826,6 +826,10 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_show_hidden_entities_clientside);
 	}
 
+	if (ORIG_ScaleColors) {
+		REG(bxt_hud_game_alpha_max_clientside);
+	}
+
 	if (ORIG_CHudFlashlight__drawNightVision_Linux || ORIG_CHudFlashlight__drawNightVision || ORIG_CHud__DrawHudNightVision_Linux || ORIG_CHud__DrawHudNightVision ) {
 		REG(bxt_disable_nightvision_sprite);
 	}
@@ -1376,6 +1380,9 @@ HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int
 		*g = custom_g;
 		*b = custom_b;
 	}
+
+	if (CVars::bxt_hud_game_alpha_max_clientside.GetBool() && !insideDrawAmmoHistory)
+		a = 255;
 
 	ORIG_ScaleColors(r, g, b, a);
 }

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -5780,8 +5780,10 @@ HOOK_DEF_8(HwDLL, void, __cdecl, Draw_FillRGBA, int, x, int, y, int, w, int, h, 
 		r = cl.custom_r;
 		g = cl.custom_g;
 		b = cl.custom_b;
-		a = 255; // SPR_Set hardcoded to 255 alpha
 	}
+
+	if (cl.custom_hud_color_set || CVars::bxt_hud_game_alpha_max_clientside.GetBool())
+		a = 255;
 
 	ORIG_Draw_FillRGBA(x, y, w, h, r, g, b, a);
 }


### PR DESCRIPTION
Forces max alpha at clientside, so default in-game colors not to be need overriden as it with `SPR_Set` method.

So, that command affects at it should if `bxt_hud_game_color` is disabled, and it useful for renders e.g.