### PR TITLE
Added bxt_disable_conback_in_demo for WON engine builds

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -37,6 +37,7 @@ namespace CVars
 	CVarWrapper bxt_force_fov("bxt_force_fov", "0");
 	CVarWrapper bxt_fix_mouse_horizontal_limit("bxt_fix_mouse_horizontal_limit", "0");
 	CVarWrapper bxt_hud_game_color("bxt_hud_game_color", "");
+	CVarWrapper bxt_disable_conback_in_demo("bxt_disable_conback_in_demo", "0");
 
 	CVarWrapper con_color;
 	CVarWrapper sv_cheats;
@@ -205,6 +206,7 @@ namespace CVars
 		&bxt_force_fov,
 		&bxt_fix_mouse_horizontal_limit,
 		&bxt_hud_game_color,
+		&bxt_disable_conback_in_demo,
 		&bxt_autojump_priority,
 		&con_color,
 		&sv_cheats,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -140,6 +140,7 @@ namespace CVars
 	extern CVarWrapper bxt_tas_write_log;
 	extern CVarWrapper bxt_tas_playback_speed;
 	extern CVarWrapper bxt_disable_vgui;
+	extern CVarWrapper bxt_disable_conback_in_demo;
 	extern CVarWrapper bxt_show_only_viewmodel;
 	extern CVarWrapper bxt_force_zmax;
 	extern CVarWrapper bxt_viewmodel_fov;

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -73,6 +73,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, SPR_Set, HSPRITE_HL hSprite, int r, int g, int b)
 	HOOK_DECL(void, __cdecl, DrawCrosshair, int x, int y)
 	HOOK_DECL(void, __cdecl, Draw_FillRGBA, int x, int y, int w, int h, int r, int g, int b, int a)
+	HOOK_DECL(void, __cdecl, Draw_ConsoleBackground, int lines)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -539,6 +539,11 @@ namespace patterns
 			"HL-WON-1712",
 			"83 EC 08 53 56 57 68 E1 0D 00 00 FF 15"
 		);
+
+		PATTERNS(Draw_ConsoleBackground,
+			"HL-WON-1712",
+			"A1 ?? ?? ?? ?? 83 EC 64"
+		);
 	}
 
 	namespace server


### PR DESCRIPTION
This command is extremely needed since I am going to re-render some old segmented run on that build.

`console 0` is disabling only characters, but not background itself, so that the reason why I did that command.

I know that porting to bxt-rs would a better solution, but there is no hooked `cl_enginefuncs` table in it, which means I cannot get easy access to the DemoAPI.