### PR TITLE
Added bxt_force_clear

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -35,6 +35,7 @@ namespace CVars
 	CVarWrapper bxt_viewmodel_semitransparent("bxt_viewmodel_semitransparent", "0");
 	CVarWrapper bxt_clear_green("bxt_clear_green", "0");
 	CVarWrapper bxt_force_fov("bxt_force_fov", "0");
+	CVarWrapper bxt_force_clear("bxt_force_clear", "0");
 	CVarWrapper bxt_fix_mouse_horizontal_limit("bxt_fix_mouse_horizontal_limit", "0");
 	CVarWrapper bxt_hud_game_color("bxt_hud_game_color", "");
 
@@ -203,6 +204,7 @@ namespace CVars
 		&bxt_viewmodel_semitransparent,
 		&bxt_clear_green,
 		&bxt_force_fov,
+		&bxt_force_clear,
 		&bxt_fix_mouse_horizontal_limit,
 		&bxt_hud_game_color,
 		&bxt_autojump_priority,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -148,6 +148,7 @@ namespace CVars
 	extern CVarWrapper bxt_viewmodel_semitransparent;
 	extern CVarWrapper bxt_clear_green;
 	extern CVarWrapper bxt_force_fov;
+	extern CVarWrapper bxt_force_clear;
 	extern CVarWrapper bxt_fix_mouse_horizontal_limit;
 	extern CVarWrapper bxt_hud_game_color;
 

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3702,6 +3702,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_viewmodel_semitransparent);
 	RegisterCVar(CVars::bxt_clear_green);
 	RegisterCVar(CVars::bxt_fix_mouse_horizontal_limit);
+	RegisterCVar(CVars::bxt_force_clear);
 
 	if (ORIG_R_SetFrustum && scr_fov_value)
 		RegisterCVar(CVars::bxt_force_fov);
@@ -5539,7 +5540,7 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_Clear)
 {
 	// This is needed or everything will look washed out or with unintended
 	// motion blur.
-	if (CVars::bxt_water_remove.GetBool() || (CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool() || CVars::bxt_show_only_viewmodel.GetBool()))) {
+	if (CVars::bxt_water_remove.GetBool() || CVars::bxt_force_clear.GetBool() || (CVars::sv_cheats.GetBool() && (CVars::bxt_wallhack.GetBool() || CVars::bxt_skybox_remove.GetBool() || CVars::bxt_show_only_viewmodel.GetBool()))) {
 		if (CVars::bxt_clear_green.GetBool())
 			glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
 		else


### PR DESCRIPTION
`gl_clear 1` acts so weird (even w/o BXT), cuz sometimes it can clear to **red** color e.g. (when I expected **black**), so that's reason why I make that cvar.

It's been mentioned years ago by shar:

![0](https://user-images.githubusercontent.com/58108407/173983209-7f373e5c-4f95-4cc5-8088-7be90a87bc4a.PNG)

