### PR TITLE
Added bxt_disable_gamedir_check_in_demo

### DIFF
--- a/BunnymodXT/cvars.cpp
+++ b/BunnymodXT/cvars.cpp
@@ -38,6 +38,7 @@ namespace CVars
 	CVarWrapper bxt_force_clear("bxt_force_clear", "0");
 	CVarWrapper bxt_fix_mouse_horizontal_limit("bxt_fix_mouse_horizontal_limit", "0");
 	CVarWrapper bxt_hud_game_color("bxt_hud_game_color", "");
+	CVarWrapper bxt_disable_gamedir_check_in_demo("bxt_disable_gamedir_check_in_demo", "0");
 
 	CVarWrapper con_color;
 	CVarWrapper sv_cheats;
@@ -213,6 +214,7 @@ namespace CVars
 		&bxt_force_clear,
 		&bxt_fix_mouse_horizontal_limit,
 		&bxt_hud_game_color,
+		&bxt_disable_gamedir_check_in_demo,
 		&bxt_autojump_priority,
 		&con_color,
 		&sv_cheats,

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -151,6 +151,7 @@ namespace CVars
 	extern CVarWrapper bxt_force_clear;
 	extern CVarWrapper bxt_fix_mouse_horizontal_limit;
 	extern CVarWrapper bxt_hud_game_color;
+	extern CVarWrapper bxt_disable_gamedir_check_in_demo;
 
 	extern CVarWrapper con_color;
 	extern CVarWrapper sv_cheats;

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -74,6 +74,7 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, DrawCrosshair, int x, int y)
 	HOOK_DECL(void, __cdecl, Draw_FillRGBA, int x, int y, int w, int h, int r, int g, int b, int a)
 	HOOK_DECL(void, __cdecl, PF_traceline_DLL, const Vector* v1, const Vector* v2, int fNoMonsters, edict_t* pentToSkip, TraceResult* ptr)
+	HOOK_DECL(qboolean, __cdecl, CL_CheckGameDirectory, char *gamedir)
 
 	struct cmdbuf_t
 	{

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -546,6 +546,13 @@ namespace patterns
 			"HL-4554",
 			"8B 44 24 10 85 C0 75 05 A1 ?? ?? ?? ?? 8B 4C 24 08 8B 54 24 04 56 50 8B 44 24 14 50 51 52 E8 ?? ?? ?? ?? D9 05"
 		);
+
+		PATTERNS(CL_CheckGameDirectory,
+			"HL-SteamPipe",
+			"55 8B EC 81 EC 04 01 00 00 56 8B 75",
+			"HL-4554",
+			"81 EC 04 01 00 00 56 8B B4 24 ?? ?? ?? ?? 85 F6"
+		);
 	}
 
 	namespace server


### PR DESCRIPTION
# Example of use-case:

HL verification moderators or usual runners want to watch demos which is been recorded on `valve` gamedir, while launching game from `valve_WON` (and vice-versa, cuz NGHL runners usually drops WON dlls to `valve` folder, while runners on HL2005 or GSP 2.3 packages playing from `valve_WON`).