### PR TITLE
Added env variable BXT_DISABLE_DEBUG_CONSOLE

### DIFF
--- a/BunnymodXT/Windows/conutils.cpp
+++ b/BunnymodXT/Windows/conutils.cpp
@@ -9,6 +9,10 @@ namespace ConUtils
 
 	void Init()
 	{
+		auto debugConsoleDisabled = std::getenv("BXT_DISABLE_DEBUG_CONSOLE");
+		if (debugConsoleDisabled)
+			return;
+		
 		AllocConsole();
 
 		hConsoleOutput = GetStdHandle(STD_OUTPUT_HANDLE);


### PR DESCRIPTION
Tested on windows 10 with goldsrc package 2.4 adding `SET BXT_DISABLE_DEBUG_CONSOLE=1` to the batch file.


https://user-images.githubusercontent.com/5108747/188501369-b1cd1591-6678-45e8-8724-8c837ed9a424.mp4

