### PR TITLE
Endsection handling

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -2455,14 +2455,30 @@ HOOK_DEF_6(ServerDLL, void, __fastcall, CTriggerEndSection__EndSectionUse, void*
 {
 	// trigger_endsection sends you to the menu, effectively stopping the demo,
 	// but not the timer and neither LiveSplit of course, so we have to do it here
-	DoAutoStopTasks();
+	if (HwDLL::GetInstance().ppGlobals) {
+		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4);
+		if (pev && pev->targetname) {
+			const char *targetname = HwDLL::GetInstance().ppGlobals->pStringBase + pev->targetname;
+			//if (!std::strcmp(targetname, "tr_endchange")) {
+				//DoAutoStopTasks();
+			//}
+		}
+	}
 
 	return ORIG_CTriggerEndSection__EndSectionUse(thisptr, edx, pActivator, pCaller, useType, value);
 }
 
 HOOK_DEF_3(ServerDLL, void, __fastcall, CTriggerEndSection__EndSectionTouch, void*, thisptr, int, edx, void*, pOther)
 {
-	DoAutoStopTasks();
+	if (HwDLL::GetInstance().ppGlobals) {
+		entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4);
+		if (pev && pev->targetname) {
+			const char *targetname = HwDLL::GetInstance().ppGlobals->pStringBase + pev->targetname;
+			if (!std::strcmp(targetname, "tr_endchange")) {
+				DoAutoStopTasks();
+			}
+		}
+	}
 
 	return ORIG_CTriggerEndSection__EndSectionTouch(thisptr, edx, pOther);
 }

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -132,7 +132,9 @@ void ServerDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* m
 			ORIG_CBaseEntity__FireBullets, HOOKED_CBaseEntity__FireBullets,
 			ORIG_CBaseEntity__FireBullets_Linux, HOOKED_CBaseEntity__FireBullets_Linux,
 			ORIG_CBaseEntity__FireBulletsPlayer, HOOKED_CBaseEntity__FireBulletsPlayer,
-			ORIG_CBaseEntity__FireBulletsPlayer_Linux, HOOKED_CBaseEntity__FireBulletsPlayer_Linux);
+			ORIG_CBaseEntity__FireBulletsPlayer_Linux, HOOKED_CBaseEntity__FireBulletsPlayer_Linux,
+			ORIG_CTriggerEndSection__EndSectionUse, HOOKED_CTriggerEndSection__EndSectionUse,
+			ORIG_CTriggerEndSection__EndSectionTouch, HOOKED_CTriggerEndSection__EndSectionTouch);
 	}
 }
 
@@ -171,7 +173,9 @@ void ServerDLL::Unhook()
 			ORIG_CBaseEntity__FireBullets_Linux,
 			ORIG_CBaseEntity__FireBulletsPlayer,
 			ORIG_CBaseEntity__FireBulletsPlayer_Linux,
-			ORIG_CBaseMonster__Killed);
+			ORIG_CBaseMonster__Killed,
+			ORIG_CTriggerEndSection__EndSectionUse,
+			ORIG_CTriggerEndSection__EndSectionTouch);
 	}
 
 	Clear();
@@ -225,6 +229,8 @@ void ServerDLL::Clear()
 	ORIG_CBaseEntity__FireBulletsPlayer = nullptr;
 	ORIG_CBaseEntity__FireBulletsPlayer_Linux = nullptr;
 	ORIG_CChangeLevel__InTransitionVolume = nullptr;
+	ORIG_CTriggerEndSection__EndSectionUse = nullptr;
+	ORIG_CTriggerEndSection__EndSectionTouch = nullptr;
 	ppmove = nullptr;
 	offPlayerIndex = 0;
 	offOldbuttons = 0;
@@ -928,6 +934,18 @@ void ServerDLL::FindStuff()
 		} else {
 			EngineDevWarning("[server dll] Could not find CChangeLevel::UseChangeLevel and CChangeLevel::TouchChangeLevel.\n");
 			EngineWarning("bxt_disable_changelevel is not available.\n");
+		}
+	}
+
+	ORIG_CTriggerEndSection__EndSectionUse = reinterpret_cast<_CTriggerEndSection__EndSectionUse>(MemUtils::GetSymbolAddress(m_Handle, "?EndSectionUse@CTriggerEndSection@@QAEXPAVCBaseEntity@@0W4USE_TYPE@@M@Z"));
+	ORIG_CTriggerEndSection__EndSectionTouch = reinterpret_cast<_CTriggerEndSection__EndSectionTouch>(MemUtils::GetSymbolAddress(m_Handle, "?EndSectionTouch@CTriggerEndSection@@QAEXPAVCBaseEntity@@@Z"));
+	{
+		if (ORIG_CTriggerEndSection__EndSectionUse && ORIG_CTriggerEndSection__EndSectionTouch) {
+			EngineDevMsg("[server dll] Found CTriggerEndSection::EndSectionUse at %p.\n", ORIG_CTriggerEndSection__EndSectionUse);
+			EngineDevMsg("[server dll] Found CTriggerEndSection::EndSectionTouch at %p.\n", ORIG_CTriggerEndSection__EndSectionTouch);
+		} else {
+			EngineDevWarning("[server dll] Could not find CTriggerEndSection::EndSectionUse and CTriggerEndSection::EndSectionTouch.\n");
+			EngineWarning("trigger_endsection automatic timer stopping is not available (e.g.: for Hazard Course).\n");
 		}
 	}
 
@@ -2431,4 +2449,20 @@ void ServerDLL::ClearBulletsEnemyTrace() {
 void ServerDLL::ClearBulletsTrace() {
 	traceLineFireBulletsPlayer.clear();
 	traceLineFireBulletsPlayerHit.clear();
+}
+
+HOOK_DEF_6(ServerDLL, void, __fastcall, CTriggerEndSection__EndSectionUse, void*, thisptr, int, edx, void*, pActivator, void*, pCaller, int, useType, float, value)
+{
+	// trigger_endsection sends you to the menu, effectively stopping the demo,
+	// but not the timer and neither LiveSplit of course, so we have to do it here
+	DoAutoStopTasks();
+
+	return ORIG_CTriggerEndSection__EndSectionUse(thisptr, edx, pActivator, pCaller, useType, value);
+}
+
+HOOK_DEF_3(ServerDLL, void, __fastcall, CTriggerEndSection__EndSectionTouch, void*, thisptr, int, edx, void*, pOther)
+{
+	DoAutoStopTasks();
+
+	return ORIG_CTriggerEndSection__EndSectionTouch(thisptr, edx, pOther);
 }

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -47,6 +47,8 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __cdecl, CBaseEntity__FireBullets_Linux, void* thisptr, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker)
 	HOOK_DECL(void, __fastcall, CBaseEntity__FireBulletsPlayer, void* thisptr, int edx, float param1, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker, int shared_rand)
 	HOOK_DECL(Vector, __cdecl, CBaseEntity__FireBulletsPlayer_Linux, void* thisptr, unsigned long cShots, Vector vecSrc, Vector vecDirShooting, Vector vecSpread, float flDistance, int iBulletType, int iTracerFreq, int iDamage, entvars_t* pevAttacker, int shared_rand)
+	HOOK_DECL(void, __fastcall, CTriggerEndSection__EndSectionUse, void* thisptr, int edx, void* pActivator, void* pCaller, int useType, float value)
+	HOOK_DECL(void, __fastcall, CTriggerEndSection__EndSectionTouch, void* thisptr, int edx, void* pOther)
 
 public:
 	static ServerDLL& GetInstance()


### PR DESCRIPTION
Hazard Course ends the game via the _trigger_endsection_ entity, and possibly some other mods or campaigns. This PR just handles this game ending method so that the timer is stopped and LiveSplit stops too, because previously we had to stop both manually when running Hazard Course and it was a bit annoying, specially when you're new to running the thing and don't know what's going on with the timer/splits.

Smiley mentioned that there's some case where sending the player to the menu via _trigger_endsection_ is not meant to end the game, but only one level or something, and then the player goes back to chapter selection or whatever and continues from there. For this reason, it won't automatically end the game on `bxt_timer_autostop 1` unless it's Hazard Course. The player will have to set `bxt_timer_autostop 2` if they actually want the game to end, so they have this workaround and they don't need to wait for someone to hardcode their mod's trigger targetname for it to work out of the box.
