### PR TITLE
Show 'MessageBox' if user downloaded a wrong version of BXT and null some pointers

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -493,7 +493,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 		if (!is_cof) {
 			ClientDLL::GetInstance().pEngfuncs = nullptr;
 			ServerDLL::GetInstance().pEngfuncs = nullptr;
-			MessageBox(NULL, "Loaded BunnymodXT (CoF edition) to non-CoF game! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
+			MessageBox(NULL, "Loaded Bunnymod XT (CoF version) in non-CoF game! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
 		}
 		#else
 		if (is_cof) {

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -499,7 +499,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 		if (is_cof) {
 			ClientDLL::GetInstance().pEngfuncs = nullptr;
 			ServerDLL::GetInstance().pEngfuncs = nullptr;
-			MessageBox(NULL, "Loaded BunnymodXT (HL edition) to CoF game! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
+			MessageBox(NULL, "Loaded BunnymodXT (HL version) in CoF! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
 		}
 		#endif
 	#endif

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -487,6 +487,22 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 			ORIG_CL_CheckGameDirectory, HOOKED_CL_CheckGameDirectory,
 			ORIG_SaveGameSlot, HOOKED_SaveGameSlot);
 	}
+
+	#ifdef _WIN32
+		#ifdef COF_BUILD
+		if (!is_cof) {
+			ClientDLL::GetInstance().pEngfuncs = nullptr;
+			ServerDLL::GetInstance().pEngfuncs = nullptr;
+			MessageBox(NULL, "Loaded BunnymodXT (CoF edition) to non-CoF game! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
+		}
+		#else
+		if (is_cof) {
+			ClientDLL::GetInstance().pEngfuncs = nullptr;
+			ServerDLL::GetInstance().pEngfuncs = nullptr;
+			MessageBox(NULL, "Loaded BunnymodXT (HL edition) to CoF game! Download the right version!", "Fatal Error", MB_OK | MB_ICONERROR);
+		}
+		#endif
+	#endif
 }
 
 void HwDLL::Unhook()


### PR DESCRIPTION
`MessageBox` is a meaningless to use since it waits from user to press **OK** for close game, while you can just ignore window and still play it....