### PR TITLE
Add bxt_tas_editor_force_mark_as_stale

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3495,9 +3495,9 @@ struct HwDLL::Cmd_Minus_BXT_TAS_Editor_Insert_Point
 	}
 };
 
-struct HwDLL::Cmd_BXT_TAS_Editor_Force_Mark_As_Stale
+struct HwDLL::Cmd_BXT_TAS_Editor_Resimulate
 {
-	USAGE("Usage: bxt_tas_editor_force_mark_as_stale\n Forces every framebulk to be stale.\n");
+	USAGE("Usage: bxt_tas_editor_resimulate\n Forces simulator client to resimulate.\n");
 
 	static void handler()
 	{
@@ -4213,7 +4213,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_FreeCam, Handler<int>>("bxt_freecam");
 	wrapper::Add<Cmd_BXT_Print_Entities, Handler<>>("bxt_print_entities");
 
-	wrapper::Add<Cmd_BXT_TAS_Editor_Force_Mark_As_Stale, Handler<>>("bxt_tas_editor_force_mark_as_stale");
+	wrapper::Add<Cmd_BXT_TAS_Editor_Resimulate, Handler<>>("bxt_tas_editor_resimulate");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Apply_Smoothing, Handler<>>("bxt_tas_editor_apply_smoothing");
 	wrapper::Add<Cmd_BXT_TAS_Optim_Init, Handler<>>("bxt_tas_optim_init");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Unset_Pitch, Handler<>>("bxt_tas_editor_unset_pitch");

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4212,7 +4212,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_Append, Handler<const char *>>("bxt_append");
 	wrapper::Add<Cmd_BXT_FreeCam, Handler<int>>("bxt_freecam");
 	wrapper::Add<Cmd_BXT_Print_Entities, Handler<>>("bxt_print_entities");
-	
+
 	wrapper::Add<Cmd_BXT_TAS_Editor_Force_Mark_As_Stale, Handler<>>("bxt_tas_editor_force_mark_as_stale");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Apply_Smoothing, Handler<>>("bxt_tas_editor_apply_smoothing");
 	wrapper::Add<Cmd_BXT_TAS_Optim_Init, Handler<>>("bxt_tas_optim_init");

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4212,7 +4212,8 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_Append, Handler<const char *>>("bxt_append");
 	wrapper::Add<Cmd_BXT_FreeCam, Handler<int>>("bxt_freecam");
 	wrapper::Add<Cmd_BXT_Print_Entities, Handler<>>("bxt_print_entities");
-
+	
+	wrapper::Add<Cmd_BXT_TAS_Editor_Force_Mark_As_Stale, Handler<>>("bxt_tas_editor_force_mark_as_stale");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Apply_Smoothing, Handler<>>("bxt_tas_editor_apply_smoothing");
 	wrapper::Add<Cmd_BXT_TAS_Optim_Init, Handler<>>("bxt_tas_optim_init");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Unset_Pitch, Handler<>>("bxt_tas_editor_unset_pitch");
@@ -4230,7 +4231,6 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_TAS_Editor_Delete_Last_Point, Handler<>>("bxt_tas_editor_delete_last_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Delete_Point, Handler<>>("bxt_tas_editor_delete_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Insert_Point, Handler<>>("bxt_tas_editor_insert_point");
-	wrapper::Add<Cmd_BXT_TAS_Editor_Force_Mark_As_Stale, Handler<>>("bxt_tas_editor_force_mark_as_stale");
 	wrapper::Add<Cmd_Plus_BXT_TAS_Editor_Insert_Point, Handler<>, Handler<int>>("+bxt_tas_editor_insert_point");
 	wrapper::Add<Cmd_Minus_BXT_TAS_Editor_Insert_Point, Handler<>, Handler<int>>("-bxt_tas_editor_insert_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Save, Handler<>>("bxt_tas_editor_save");

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3495,6 +3495,23 @@ struct HwDLL::Cmd_Minus_BXT_TAS_Editor_Insert_Point
 	}
 };
 
+struct HwDLL::Cmd_BXT_TAS_Editor_Force_Mark_As_Stale
+{
+	USAGE("Usage: bxt_tas_editor_force_mark_as_stale\n Forces every framebulk to be stale.\n");
+
+	static void handler()
+	{
+		auto& hw = HwDLL::GetInstance();
+		auto& frame_bulks = hw.tas_editor_input.frame_bulks;
+
+		if (hw.tas_editor_mode == TASEditorMode::EDIT) {
+			if (frame_bulks.size() > 0) {
+				hw.tas_editor_input.mark_as_stale(0);
+			}
+		}
+	}
+};
+
 struct HwDLL::Cmd_BXT_TAS_Editor_Toggle
 {
 	USAGE("Usage: bxt_tas_editor_toggle <what>\n Toggles a function on the currently selected point. You can toggle:\n"
@@ -4213,6 +4230,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_TAS_Editor_Delete_Last_Point, Handler<>>("bxt_tas_editor_delete_last_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Delete_Point, Handler<>>("bxt_tas_editor_delete_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Insert_Point, Handler<>>("bxt_tas_editor_insert_point");
+	wrapper::Add<Cmd_BXT_TAS_Editor_Force_Mark_As_Stale, Handler<>>("bxt_tas_editor_force_mark_as_stale");
 	wrapper::Add<Cmd_Plus_BXT_TAS_Editor_Insert_Point, Handler<>, Handler<int>>("+bxt_tas_editor_insert_point");
 	wrapper::Add<Cmd_Minus_BXT_TAS_Editor_Insert_Point, Handler<>, Handler<int>>("-bxt_tas_editor_insert_point");
 	wrapper::Add<Cmd_BXT_TAS_Editor_Save, Handler<>>("bxt_tas_editor_save");

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -451,7 +451,7 @@ protected:
 	struct Cmd_BXT_TAS_Editor_Insert_Point;
 	struct Cmd_Plus_BXT_TAS_Editor_Insert_Point;
 	struct Cmd_Minus_BXT_TAS_Editor_Insert_Point;
-	struct Cmd_BXT_TAS_Editor_Force_Mark_As_Stale;
+	struct Cmd_BXT_TAS_Editor_Resimulate;
 	struct Cmd_BXT_TAS_Editor_Toggle;
 	struct Cmd_BXT_TAS_Editor_Set_Frametime;
 	struct Cmd_BXT_TAS_Editor_Set_Change_Type;

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -451,6 +451,7 @@ protected:
 	struct Cmd_BXT_TAS_Editor_Insert_Point;
 	struct Cmd_Plus_BXT_TAS_Editor_Insert_Point;
 	struct Cmd_Minus_BXT_TAS_Editor_Insert_Point;
+	struct Cmd_BXT_TAS_Editor_Force_Mark_As_Stale;
 	struct Cmd_BXT_TAS_Editor_Toggle;
 	struct Cmd_BXT_TAS_Editor_Set_Frametime;
 	struct Cmd_BXT_TAS_Editor_Set_Change_Type;


### PR DESCRIPTION
Especially useful when some weird RNG stuffs happen somewhere before the current framebulk and it is just movement section and it is in EDIT mode and the framebulk is nowhere to be seen.