### PR TITLE
EntityInfo: draw damage for func_door/func_rotating/func_train

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -867,6 +867,9 @@ namespace CustomHud
 						out << "Monsters: Can open" << '\n';
 				}
 
+				if ((strstr(classname, "func_door") != NULL) || (strncmp(classname, "func_rotating", 13) == NULL) || (strncmp(classname, "func_train", 10) == NULL))
+					out << "Damage: " << ent->v.dmg << '\n';
+
 				if (CVars::bxt_hud_entity_info.GetInt() == 2)
 				{
 					out << "Yaw: " << ent->v.angles[1] << '\n';
@@ -946,7 +949,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_selfgauss.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_selfgauss_offset, CVars::bxt_hud_selfgauss_anchor, &x, &y, -200, (si.iCharHeight * 31) + 3);
+			GetPosition(CVars::bxt_hud_selfgauss_offset, CVars::bxt_hud_selfgauss_anchor, &x, &y, -200, (si.iCharHeight * 32) + 3);
 
 			bool selfgaussable;
 			int hitGroup = 0; // It's always initialized if selfgaussable is set to true, but GCC issues a warning anyway.
@@ -1004,7 +1007,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_armor.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_armor_offset, CVars::bxt_hud_armor_anchor, &x, &y, -200, (si.iCharHeight * 34) + 3);
+			GetPosition(CVars::bxt_hud_armor_offset, CVars::bxt_hud_armor_anchor, &x, &y, -200, (si.iCharHeight * 35) + 3);
 
 			std::ostringstream out;
 			out.setf(std::ios::fixed);
@@ -1020,7 +1023,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_waterlevel.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_waterlevel_offset, CVars::bxt_hud_waterlevel_anchor, &x, &y, -200, (si.iCharHeight * 35) + 3);
+			GetPosition(CVars::bxt_hud_waterlevel_offset, CVars::bxt_hud_waterlevel_anchor, &x, &y, -200, (si.iCharHeight * 36) + 3);
 
 			std::ostringstream out;
 			out.setf(std::ios::fixed);
@@ -1038,7 +1041,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_nihilanth.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 36) + 3);
+			GetPosition(CVars::bxt_hud_nihilanth_offset, CVars::bxt_hud_nihilanth_anchor, &x, &y, -200, (si.iCharHeight * 37) + 3);
 
 			std::ostringstream out;
 			out << "Nihilanth:\n";
@@ -1072,7 +1075,7 @@ namespace CustomHud
 		if (CVars::bxt_hud_gonarch.GetBool())
 		{
 			int x, y;
-			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 43) + 3);
+			GetPosition(CVars::bxt_hud_gonarch_offset, CVars::bxt_hud_gonarch_anchor, &x, &y, -200, (si.iCharHeight * 44) + 3);
 
 			std::ostringstream out;
 			out << "Gonarch:\n";


### PR DESCRIPTION
Looking to HLSDK code, I realized that not only doors can give a infinite health for blocked player if `dmg` set to negative value, `func_rotating` and `func_train` entities can do that as well.