### PR TITLE
Register 'bxt_remove_punchangles" if V_CalcRefDef found

### DIFF
--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -940,6 +940,7 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_viewmodel_ofs_right);
 		REG(bxt_viewmodel_ofs_up);
 		REG(bxt_viewmodel_bob_angled);
+		REG(bxt_remove_punchangles);
 	}
 
 	if (ORIG_HUD_Init)
@@ -1050,9 +1051,6 @@ void ClientDLL::RegisterCVarsAndCommands()
 
 	if (pCS_SpeedScaling || pCS_SpeedScaling_Linux) {
 		REG(bxt_speed_scaling);
-	}
-	if (ORIG_V_PunchAxis) {
-		REG(bxt_remove_punchangles);
 	}
 	#undef REG
 }


### PR DESCRIPTION
In modifications as **Cry of Fear** and **PARANOIA** - function `V_PunchAxis` not used and code deleted from it.

Those mods writes punch values to `vuser3` variable, `PM_DropPunchAngle` converts `vuser3` to `punchangle`, which in the end applies to viewangles in `V_CalcNormalRefdef`.

Set `pparams->punchangle` to `0.0f` is enough to disable the entire punch system in that two mods.