### PR TITLE
Linux offsets: use strcmp instead of strstr to check if gamedir is 'dmc'

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1021,7 +1021,7 @@ void ServerDLL::FindStuff()
 					offFuncCenter = 0xE0;
 					offFuncObjectCaps = 0x20;
 				}
-				if (ClientDLL::GetInstance().DoesGameDirContain("dmc")) {
+				if (ClientDLL::GetInstance().DoesGameDirMatch("dmc")) {
 					offm_rgAmmoLast = 0x534;
 					offm_iClientFOV = 0x48C;
 				}


### PR DESCRIPTION
That's like a safe check in cases if some modification directory starts from `dmc`