### PR TITLE
linux: Remove Hooks::Free() from destructor

### DIFF
--- a/BunnymodXT/Linux/main_linux.cpp
+++ b/BunnymodXT/Linux/main_linux.cpp
@@ -105,8 +105,6 @@ static __attribute__((constructor(1337))) void Construct()
 // Destructor priority must be the same as constructor.
 static __attribute__((destructor(1337))) void Destruct()
 {
-	Hooks::Free();
-
 	if (logfile)
 		fclose(logfile);
 


### PR DESCRIPTION
This is causing a segfault on a Flatpak build for whatever reason trying to access name of a module. We're exiting anyway, don't need to unhook.