### PR TITLE
Split 'ShiftMonsters' to a new separate cvar

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -80,6 +80,7 @@
 	X(bxt_remove_stamina, "0") \
 	X(bxt_cof_enable_ducktap, "0") \
 	X(bxt_cof_slowdown_if_use_on_ground, "0") \
+	X(bxt_cof_disable_monsters_teleport_to_spawn_after_load, "0") \
 	X(bxt_cof_disable_viewpunch_from_jump, "0") \
 	X(cl_righthand, "0") \
 	X(bxt_remove_punchangles, "0") \

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1596,6 +1596,8 @@ void ServerDLL::RegisterCVarsAndCommands()
 		REG(bxt_cof_disable_save_lock);
 	if (ORIG_CBasePlayer__ViewPunch && is_cof)
 		REG(bxt_cof_disable_viewpunch_from_jump);
+	if (ORIG_ShiftMonsters && is_cof)
+		REG(bxt_cof_disable_monsters_teleport_to_spawn_after_load);
 
 	REG(bxt_splits_print);
 	REG(bxt_splits_print_times_at_end);
@@ -3166,7 +3168,7 @@ HOOK_DEF_0(ServerDLL, void, __cdecl, PM_UnDuck)
 HOOK_DEF_1(ServerDLL, void, __cdecl, ShiftMonsters, Vector, origin)
 {
 	// Cry of Fear-specific, fix monsters teleport to their spawn points.
-	if (CVars::bxt_cof_disable_save_lock.GetBool())
+	if (CVars::bxt_cof_disable_monsters_teleport_to_spawn_after_load.GetBool())
 		return;
 	else
 		return ORIG_ShiftMonsters(origin);


### PR DESCRIPTION
In `Cry of Fear 1.1` it possible to legit saveload, but that version **doesn't** teleport monsters to their spawn positions

In `Cry of Fear 1.4` it possible to legit saveload, but that version **does** teleport monsters to their spawn positions

So if example you don't feel like downloading a mod version of the game, then you can more or less emulate functionality from some of those versions, but yeah I know that not kinda legit of course.