### PR TITLE
rpc: removed extra definition for chapter of the same map (ba_security1)

### DIFF
--- a/BunnymodXT/discord_integration.hpp
+++ b/BunnymodXT/discord_integration.hpp
@@ -271,7 +271,6 @@ namespace discord_integration
 			{"ba_tram1", "bschapter9"},
 			{"ba_tram2", "bschapter9"},
 			{"ba_tram3", "bschapter9"},
-			{"ba_security1", "bschapter9"},
 		};
 
 		const std::unordered_map<std::string_view, std::string_view> gmc_thumbnail_to_chapter = {


### PR DESCRIPTION
It didn't affect anything even without of that change, when I made those lists I did a lot of CTRL+C and CTRL+V and I didn't noticed that I wrote the same map twice, I only noticed this yesterday when used map lists for something in `discord_integration.hpp` lmao