### PR TITLE
Change bxt_show_splits default to 0

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -206,7 +206,7 @@
 	X(bxt_show_bullets_enemy, "0") \
 	X(bxt_anglespeed_cap, "1") \
 	X(bxt_speed_scaling, "1") \
-	X(bxt_show_splits, "1") \
+	X(bxt_show_splits, "0") \
 	X(bxt_splits_color, "") \
 	X(bxt_splits_print, "1") \
 	X(bxt_splits_print_times_at_end, "1") \


### PR DESCRIPTION
It's similar to bxt_show_custom_triggers which is disallowed in runs. Supermods asked to change this to 0 too so runners don't accidentally invalidate their run.

cc @fireblizzard