### PR TITLE
ClientCommand: add 'give' support for Cry of Fear

### DIFF
--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -131,6 +131,8 @@ protected:
 	_CBasePlayer__GiveNamedItem ORIG_CBasePlayer__GiveNamedItem;
 	typedef void(__cdecl *_CBasePlayer__GiveNamedItem_Linux)(void *thisptr, const char *pszName);
 	_CBasePlayer__GiveNamedItem_Linux ORIG_CBasePlayer__GiveNamedItem_Linux;
+	typedef void(__fastcall *_CoF_CBasePlayer__GiveNamedItem)(void *thisptr, int edx, const char *pszName, bool deletewhendropped);
+	_CoF_CBasePlayer__GiveNamedItem ORIG_CoF_CBasePlayer__GiveNamedItem;
 
 	typedef bool (__fastcall *_IsPlayer)(void *thisptr);
 	typedef void (__fastcall *_Center)(void *thisptr, int edx, Vector *center);

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -885,6 +885,13 @@ namespace patterns
 			"8B 44 24 ?? 56 57 8B F9 8B 0D ?? ?? ?? ?? 2B 81 ?? ?? ?? ?? 50 E8"
 		);
 
+		PATTERNS(CoF_CBasePlayer__GiveNamedItem,
+			"CoF-Mod-155",
+			"55 8B EC 83 EC 4C 53 56 57 89 4D ?? 83 7D ?? 00 74",
+			"CoF-5936",
+			"55 8B EC 53 8B 5D ?? 57 8B F9 85 DB 0F 84 ?? ?? ?? ?? BA"
+		);
+
 		PATTERNS(CPushable__Move,
 			"HL-SteamPipe",
 			"53 56 8B F1 8B 4C 24 0C 57 33 DB 8B 79 04 8B 87 A4 01 00 00 F6 C4 02 74 3A 8B 87 9C 01 00 00 85 C0 74 30 8D 90 80 00 00 00 8B 46 04",


### PR DESCRIPTION
Proof that `GiveNamedItem` having a one more argument in CoF comparing to HLSDK code (thanks to leftover .pdb for server-side from developer of game in *cl_dlls* folder):


![0](https://user-images.githubusercontent.com/58108407/223617362-87694f5e-cd43-4799-8d4a-fe4a2ebbce29.PNG)

