### PR TITLE
Permanently reverted 'bxt_hud_game_alpha' back and add 'bxt_hud_game_alpha_damage'

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -114,7 +114,7 @@
 	X(bxt_unlock_camera_during_pause, "0") \
 	X(bxt_hud, "1") \
 	X(bxt_hud_color, "") \
-	X(bxt_hud_game_alpha_max_clientside, "0") \
+	X(bxt_hud_game_alpha, "0") \
 	X(bxt_hud_precision, "6") \
 	X(bxt_hud_quickgauss, "0") \
 	X(bxt_hud_quickgauss_offset, "") \

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -115,6 +115,7 @@
 	X(bxt_hud, "1") \
 	X(bxt_hud_color, "") \
 	X(bxt_hud_game_alpha, "0") \
+	X(bxt_hud_game_alpha_damage, "0") \
 	X(bxt_hud_precision, "6") \
 	X(bxt_hud_quickgauss, "0") \
 	X(bxt_hud_quickgauss_offset, "") \

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1092,6 +1092,10 @@ void ClientDLL::RegisterCVarsAndCommands()
 	if (pCS_SpeedScaling || pCS_SpeedScaling_Linux) {
 		REG(bxt_speed_scaling);
 	}
+
+	if ((ORIG_CHudHealth__DrawDamage || ORIG_CHudHealth__DrawDamage_Linux) && ORIG_ScaleColors) {
+		REG(bxt_hud_game_alpha_damage);
+	}
 	#undef REG
 }
 
@@ -2001,6 +2005,11 @@ HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int
 	if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255 && !insideDrawAmmoHistory && !insideDrawHealthDamage && !insideDrawHealthPain)
 		a = CVars::bxt_hud_game_alpha.GetInt();
 
+	if (insideDrawHealthDamage && CVars::bxt_hud_game_alpha_damage.GetBool() && CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255)
+	{
+		a = static_cast<int>(std::fabs(std::sin(drawdamage_flTime*2.0f)) * CVars::bxt_hud_game_alpha.GetFloat());
+	}
+
 	ORIG_ScaleColors(r, g, b, a);
 }
 
@@ -2024,6 +2033,7 @@ HOOK_DEF_2(ClientDLL, int, __cdecl, HistoryResource__DrawAmmoHistory_Linux, void
 
 HOOK_DEF_3(ClientDLL, int, __fastcall, CHudHealth__DrawDamage, void*, thisptr, int, edx, float, flTime)
 {
+	drawdamage_flTime = flTime;
 	insideDrawHealthDamage = true;
 	auto ret = ORIG_CHudHealth__DrawDamage(thisptr, edx, flTime);
 	insideDrawHealthDamage = false;
@@ -2033,6 +2043,7 @@ HOOK_DEF_3(ClientDLL, int, __fastcall, CHudHealth__DrawDamage, void*, thisptr, i
 
 HOOK_DEF_2(ClientDLL, int, __cdecl, CHudHealth__DrawDamage_Linux, void*, thisptr, float, flTime)
 {
+	drawdamage_flTime = flTime;
 	insideDrawHealthDamage = true;
 	auto ret = ORIG_CHudHealth__DrawDamage_Linux(thisptr, flTime);
 	insideDrawHealthDamage = false;

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1078,7 +1078,7 @@ void ClientDLL::RegisterCVarsAndCommands()
 	}
 
 	if (ORIG_ScaleColors) {
-		REG(bxt_hud_game_alpha_max_clientside);
+		REG(bxt_hud_game_alpha);
 	}
 
 	if (ORIG_CHudFlashlight__drawNightVision_Linux || ORIG_CHudFlashlight__drawNightVision || ORIG_CHud__DrawHudNightVision_Linux || ORIG_CHud__DrawHudNightVision ) {
@@ -1998,8 +1998,8 @@ HOOK_DEF_4(ClientDLL, void, __cdecl, ScaleColors, int*, r, int*, g, int*, b, int
 		*b = custom_b;
 	}
 
-	if (CVars::bxt_hud_game_alpha_max_clientside.GetBool() && !insideDrawAmmoHistory && !insideDrawHealthDamage && !insideDrawHealthPain)
-		a = 255;
+	if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255 && !insideDrawAmmoHistory && !insideDrawHealthDamage && !insideDrawHealthPain)
+		a = CVars::bxt_hud_game_alpha.GetInt();
 
 	ORIG_ScaleColors(r, g, b, a);
 }

--- a/BunnymodXT/modules/ClientDLL.hpp
+++ b/BunnymodXT/modules/ClientDLL.hpp
@@ -97,6 +97,7 @@ public:
 	bool insideDrawNightVision = false;
 	bool insideDrawFiberCameraCZDS = false;
 	bool insideDrawHudIconsCZDS = false;
+	float drawdamage_flTime;
 
 	unsigned short last_buttons;
 

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -7312,8 +7312,10 @@ HOOK_DEF_8(HwDLL, void, __cdecl, Draw_FillRGBA, int, x, int, y, int, w, int, h, 
 		b = cl.custom_b;
 	}
 
-	if (cl.custom_hud_color_set || CVars::bxt_hud_game_alpha_max_clientside.GetBool())
+	if (cl.custom_hud_color_set)
 		a = 255;
+	else if (CVars::bxt_hud_game_alpha.GetInt() >= 1 && CVars::bxt_hud_game_alpha.GetInt() <= 255)
+		a = CVars::bxt_hud_game_alpha.GetInt();
 
 	ORIG_Draw_FillRGBA(x, y, w, h, r, g, b, a);
 }


### PR DESCRIPTION
Talked with friend about rendering runs, and we got into conclusion that `bxt_hud_game_alpha` should be returned in replace of `bxt_hud_game_alpha_max_clientside`

If you have a question what is that specific code in `bxt_hud_game_alpha_damage`: https://github.com/ValveSoftware/halflife/blob/master/cl_dll/health.cpp#L377
That makes smoothly fading HUD damage icons from alpha that specified in **bxt_hud_game_alpha** to `0` (cuz by default it is hardcoded to max value aka `256.0`)

If you do not understand what are these damage icons that are talking about:

![изображение](https://user-images.githubusercontent.com/58108407/223615412-0691ee41-2c15-481d-960e-ad80dfb160b1.png)
