### PR TITLE
Fixed data types from 'bool' to 'qboolean' (int) for some variables

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -1618,7 +1618,7 @@ void HwDLL::FindStuff()
 					svs = reinterpret_cast<svs_t*>(*reinterpret_cast<uintptr_t*>(f + 79) - 8);
 					offEdict = *reinterpret_cast<ptrdiff_t*>(f + 182);
 					offActiveAddr = *reinterpret_cast<uintptr_t*>(f + 0x32);
-					cofSaveHack = *reinterpret_cast<bool**>(f + 21);
+					cofSaveHack = *reinterpret_cast<qboolean**>(f + 21);
 					is_cof_steam = true;
 					break;
 				}
@@ -1935,13 +1935,13 @@ void HwDLL::FindStuff()
 				{
 				default:
 				case 0: // CoF-5936.
-					noclip_anglehack = *reinterpret_cast<bool**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 216);
+					noclip_anglehack = *reinterpret_cast<qboolean**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 216);
 					break;
 				case 1: // Steampipe.
-					noclip_anglehack = *reinterpret_cast<bool**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 237);
+					noclip_anglehack = *reinterpret_cast<qboolean**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 237);
 					break;
 				case 2: // 4554.
-					noclip_anglehack = *reinterpret_cast<bool**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 204);
+					noclip_anglehack = *reinterpret_cast<qboolean**>(reinterpret_cast<uintptr_t>(CL_RegisterResources) + 204);
 					break;
 				}
 			});

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -516,7 +516,7 @@ public:
 
 	bool ducktap;
 	edict_t **sv_player;
-	bool *noclip_anglehack;
+	qboolean *noclip_anglehack;
 protected:
 	void KeyDown(Key& btn);
 	void KeyUp(Key& btn);
@@ -560,7 +560,7 @@ protected:
 	studiohdr_t **pstudiohdr;
 	float *scr_fov_value;
 	ptrdiff_t pHost_FilterTime_FPS_Cap_Byte;
-	bool *cofSaveHack; // Cry of Fear-specific
+	qboolean *cofSaveHack; // Cry of Fear-specific
 
 	int framesTillExecuting;
 	bool executing;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1761,7 +1761,7 @@ void ServerDLL::LogPlayerMove(bool pre, uintptr_t pmove) const
 	const float *baseVelocity = reinterpret_cast<const float *>(pmove + offBasevelocity);
 	const float *origin = reinterpret_cast<const float *>(pmove + offOrigin);
 	const int *flags = reinterpret_cast<const int *>(pmove + offFlags);
-	const bool *inDuck = reinterpret_cast<const bool *>(pmove + offInDuck);
+	const int *inDuck = reinterpret_cast<const int *>(pmove + offInDuck);
 	const int *groundEntity = reinterpret_cast<const int *>(pmove + offOnground);
 	const int *waterLevel = reinterpret_cast<const int *>(pmove + offWaterlevel);
 
@@ -3172,7 +3172,7 @@ HOOK_DEF_0(ServerDLL, void, __cdecl, PM_UnDuck)
 	if (ppmove && offFlags && offInDuck && CVars::bxt_cof_enable_ducktap.GetBool()) {
 		auto pmove = reinterpret_cast<uintptr_t>(*ppmove);
 		int *flags = reinterpret_cast<int*>(pmove + offFlags);
-		bool *inDuck = reinterpret_cast<bool*>(pmove + offInDuck);
+		qboolean *inDuck = reinterpret_cast<qboolean*>(pmove + offInDuck);
 		*flags |= FL_DUCKING;
 		*inDuck = false;
 	}


### PR DESCRIPTION
I must to say that it isn't caused any issues in-game for all this time, it just my curiosity which decided to double-check the BXT code for data types of variables, and then I remembered about `bool` and `qboolean` and their differences:

Definition of `qboolean` in C++ code is an **int** - which weights is `4` bytes, while `bool` from C++ equals to `1` byte

Proof that those variables is `qboolean` (int):

`noclip_anglehack` = https://github.com/id-Software/Quake/blob/bf4ac424ce754894ac8f1dae6a3981954bc9852d/WinQuake/host_cmd.c#L149 (that could be also confirmed from debug information of `hw.so` aka GoldSrc engine)
`bInDuck` = https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/pm_shared/pm_defs.h#L110