### PR TITLE
Add runtime data parsing and demo accurate timer

### DIFF
--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -1868,6 +1868,10 @@ namespace CustomHud
 			milliseconds };
 	}
 
+	void SetTime(int h, int m, int s, double r) {
+		hours = h, minutes = m, seconds = s, timeRemainder = r;
+	}
+
 	bool GetCountingTime()
 	{
 		return countingTime;

--- a/BunnymodXT/hud_custom.hpp
+++ b/BunnymodXT/hud_custom.hpp
@@ -24,6 +24,7 @@ namespace CustomHud
 	void UpdatePlayerInfoInaccurate(float vel[3], float org[3]);
 
 	void TimePassed(double time);
+	void SetTime(int hours, int minutes, int seconds, double remainder);
 	void ResetTime();
 	void SetCountingTime(bool counting);
 	void SetInvalidRun(bool invalidated);

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -81,6 +81,8 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(void, __cdecl, SCR_NetGraph)
 	HOOK_DECL(void, __cdecl, Host_Shutdown)
 	HOOK_DECL(void, __cdecl, ReleaseEntityDlls)
+	HOOK_DECL(qboolean, __cdecl, ValidStuffText, char* buf)
+	HOOK_DECL(qboolean, __cdecl, CL_ReadDemoMessage_OLD)
 
 	struct cmdbuf_t
 	{
@@ -725,4 +727,7 @@ protected:
 	bool insideHideGameUI;
 
 	bool extendPlayerTraceDistanceLimit;
+
+	bool insideCL_ReadDemoMessage;
+	std::vector<char> runtimeDataBuffer;
 };

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -782,6 +782,16 @@ namespace patterns
 			"CoF-5936",
 			"55 8B EC 83 EC 08 C7 45 ?? ?? ?? ?? ?? A1 ?? ?? ?? ?? 6B C0 0C"
 		);
+
+		PATTERNS(ValidStuffText,
+			"HL-SteamPipe",
+			"55 8B EC 53 56 57 BB 01 00 00 00 E8 E0 9D 03 00 85 C0 74 10 A1 ?? ?? ?? ?? 85 C0 75 07 5F 8B C3 5E 5B 5D C3"
+		);
+
+		PATTERNS(CL_ReadDemoMessage_OLD,
+			"HL-SteamPipe",
+			"55 8B EC B8 74 00 01 00 E8 66 6D 0F 00 A1 ?? ?? ?? ?? 53 33 DB 56 3B C3 57"
+		);
 	}
 
 	namespace server

--- a/BunnymodXT/runtime_data.cpp
+++ b/BunnymodXT/runtime_data.cpp
@@ -368,6 +368,118 @@ namespace RuntimeData
 		boost::apply_visitor(save_visitor<Archive>(archive), data);
 	}
 
+	template<class Archive>
+	void load(Archive& archive, Data& data)
+	{
+		RuntimeDataType data_type;
+		archive(data_type);
+
+		switch (data_type)
+		{
+			case RuntimeDataType::VERSION_INFO: {
+				VersionInfo v;
+				archive(v.build_number);
+				archive(v.bxt_version);
+
+				data = v;
+				break;
+			}
+			case RuntimeDataType::CVAR_VALUES: {
+				CVarValues v;
+				archive(v);
+				data = v;
+				break;
+			}
+			case RuntimeDataType::TIME: {
+				Time t;
+				archive(t.hours);
+				archive(t.minutes);
+				archive(t.seconds);
+				archive(t.remainder);
+				data = t;
+				break;
+			}
+			case RuntimeDataType::BOUND_COMMAND: {
+				BoundCommand c;
+				archive(c.command);
+				data = c;
+				break;
+			}
+			case RuntimeDataType::ALIAS_EXPANSION: {
+				AliasExpansion e;
+				archive(e.name);
+				archive(e.command);
+				data = e;
+				break;
+			}
+			case RuntimeDataType::SCRIPT_EXECUTION: {
+				ScriptExecution e;
+				archive(e.filename);
+				archive(e.contents);
+				data = e;
+				break;
+			}
+			case RuntimeDataType::COMMAND_EXECUTION: {
+				CommandExecution e;
+				archive(e.command);
+				data = e;
+				break;
+			}
+			case RuntimeDataType::GAME_END_MARKER: {
+				GameEndMarker m;
+				data = m;
+				break;
+			}
+			case RuntimeDataType::LOADED_MODULES: {
+				LoadedModules m;
+				archive(m.filenames);
+				data = m;
+				break;
+			}
+			case RuntimeDataType::CUSTOM_TRIGGER_COMMAND: {
+				CustomTriggerCommand c;
+				archive(c.corner_min.x);
+				archive(c.corner_min.y);
+				archive(c.corner_min.z);
+				archive(c.corner_max.x);
+				archive(c.corner_max.y);
+				archive(c.corner_max.z);
+				archive(c.command);
+				data = c;
+				break;
+			}
+			case RuntimeDataType::EDICTS: {
+				Edicts e;
+				archive(e.edicts);
+				data = e;
+				break;
+			}
+			case RuntimeDataType::PLAYERHEALTH: {
+				PlayerHealth p;
+				archive(p.health);
+				data = p;
+				break;
+			}
+			case RuntimeDataType::SPLIT_MARKER: {
+				SplitMarker m;
+				archive(m.corner_min.x);
+				archive(m.corner_min.y);
+				archive(m.corner_min.z);
+				archive(m.corner_max.x);
+				archive(m.corner_max.y);
+				archive(m.corner_max.z);
+				archive(m.name);
+				archive(m.map_name);
+				data = m;
+				break;
+			}
+			default: {
+				EngineDevWarning("Read unknown RuntimeDataType %d\n", data_type);
+				break;
+			}
+		}
+	}
+
 	void Add(Data data) {
 		stored_data.push_back(std::move(data));
 	}

--- a/BunnymodXT/runtime_data.hpp
+++ b/BunnymodXT/runtime_data.hpp
@@ -80,4 +80,6 @@ namespace RuntimeData
 	void Add(Data data);
 	void Clear();
 	void SaveStored();
+
+	void ProcessRuntimeData(std::vector<char>& data);
 }


### PR DESCRIPTION
Adds 2 hw.dll hooks:
- ValidStuffText 
- CL_ReadDemoMessage_OLD

That are used to read the //BXTD0 commands and corresponding runtime data each frame. These have only been tested on latest steam version of Half-Life.

Conversion back to a vector<Data> was implemented by adding a decrypt filter and load template.
demo_data_visitor is then applied to the recovered data and should contain logic such as updating timer/health. This could arguably be part of the load template, but imo it's better for parse logic to be separate. 

I currently set HwDll::executing to true whenever a demo frame is read, to make the timer resume after save/loads. This is scuffed, and the Cbuf_Execute hook should be fixed to resume in demos instead, but I dont know how to.

Can be used to resolve #294