### PR TITLE
Added CVars to restore WON view rolling effects

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -210,6 +210,9 @@
 	X(bxt_viewmodel_ofs_right, "0") \
 	X(bxt_viewmodel_ofs_up, "0") \
 	X(bxt_viewmodel_bob_angled, "0") \
+	X(bxt_viewmodel_restore_viewroll, "0") \
+	X(bxt_viewmodel_viewrollangle, "2.0") \
+	X(bxt_viewmodel_viewrollspeed, "200") \
 	X(bxt_show_bullets, "0") \
 	X(bxt_show_bullets_enemy, "0") \
 	X(bxt_anglespeed_cap, "1") \

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -973,6 +973,9 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_viewmodel_ofs_up);
 		REG(bxt_viewmodel_bob_angled);
 		REG(bxt_remove_punchangles);
+		REG(bxt_viewmodel_restore_viewroll);
+		REG(bxt_viewmodel_viewrollangle);
+		REG(bxt_viewmodel_viewrollspeed);
 	}
 
 	if (ORIG_HUD_Init)
@@ -1479,6 +1482,19 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, V_CalcRefdef, ref_params_t*, pparams)
 
 	if (unlock_camera)
 		pparams->paused = false;
+
+	auto restore_view_roll = CVars::bxt_viewmodel_restore_viewroll.GetBool();
+
+	// We set the rollspeed and rollangle values here before calling the original V_CalcRefDef
+	// These two values are not used for anything else in the original function apart from
+	// applying the view rolling effect, so it is safe to edit them here.
+	if (restore_view_roll) {
+		auto rollangle = CVars::bxt_viewmodel_viewrollangle.GetFloat();
+		auto rollspeed = CVars::bxt_viewmodel_viewrollspeed.GetFloat();
+
+		pparams->movevars->rollangle = rollangle;
+		pparams->movevars->rollspeed = rollspeed;
+	}
 
 	ORIG_V_CalcRefdef(pparams);
 

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1483,7 +1483,7 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, V_CalcRefdef, ref_params_t*, pparams)
 	if (unlock_camera)
 		pparams->paused = false;
 
-	auto restore_view_roll = CVars::bxt_viewmodel_restore_viewroll.GetBool();
+	auto restore_view_roll = CVars::bxt_viewmodel_restore_viewroll.GetBool() && CVars::sv_cheats.GetBool();
 
 	// We set the rollspeed and rollangle values here before calling the original V_CalcRefDef
 	// These two values are not used for anything else in the original function apart from


### PR DESCRIPTION
See issue in the original HL SDK repo: https://github.com/ValveSoftware/halflife/issues/1544

The viewroll effect was removed sometime when HL came to Steam. Since BunnymodXT can restore the weapon bob effect, I thought it would have been nice for it to also being able to restore the viewroll effect. The values are slightly different from the one in the issue above, and have been taken from the implementation used in halflife-updated (see: https://github.com/SamVanheer/halflife-updated/commit/dcd3e93a5abcf151c287c68d166953f8b400c7a5 ) which gives a nicer effect.
This PR adds cvars to restore the viewroll effect (defaults to false) and set the rollspeed and rollangle values.