### PR TITLE
Add hook for TAS Studio stop until stop frame

### DIFF
--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -353,6 +353,8 @@ public:
 	void TimerReset();
 	void TimerStart();
 
+	int tas_studio_norefresh_override = 0;
+
 private:
 	// Make sure to have hl.exe last here, so that it is the lowest priority.
 	HwDLL() : IHookableNameFilterOrdered({ L"hw.dll", L"hw.so", L"sw.dll", L"hl.exe" }) {};


### PR DESCRIPTION
Very scuffed because things don't go with the order I want. Lines where it sets the overridden value back to 0 is in case someone wants to do normal bxt_tas_loadscript. It is tricky to put that into reset functions because of how the value is passed in.