### PR TITLE
Add bxt_ch_checkpoint

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -225,7 +225,9 @@
 	X(bxt_splits_autorecord_on_first_split, "") \
 	X(bxt_splits_start_timer_on_first_split, "0") \
 	X(bxt_splits_end_on_last_split, "0") \
-	X(bxt_ch_hook_speed, "869")
+	X(bxt_ch_hook_speed, "869") \
+	X(bxt_ch_checkpoint_with_vel, "0") \
+	X(bxt_ch_checkpoint_onground_only, "1")
 
 class CVarWrapper
 {

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3202,7 +3202,7 @@ void HwDLL::ChHookPlayer() {
 	pl->v.velocity = target;
 }
 
-struct HwDLL::Cmd_BXT_CH_CheckPoint
+struct HwDLL::Cmd_BXT_CH_CheckPoint_Create
 {
 	NO_USAGE();
 
@@ -3238,7 +3238,7 @@ struct HwDLL::Cmd_BXT_CH_CheckPoint
 	}
 };
 
-struct HwDLL::Cmd_BXT_CH_GoCheck
+struct HwDLL::Cmd_BXT_CH_CheckPoint_GoTo
 {
 	NO_USAGE();
 
@@ -5363,8 +5363,8 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 		Handler<float, float, float>>("bxt_ch_set_vel_angles");
 	wrapper::AddCheat<Cmd_Plus_BXT_CH_Hook, Handler<>, Handler<int>>("+bxt_ch_hook");
 	wrapper::AddCheat<Cmd_Minus_BXT_CH_Hook, Handler<>, Handler<int>>("-bxt_ch_hook");
-	wrapper::AddCheat<Cmd_BXT_CH_CheckPoint, Handler<>>("bxt_ch_checkpoint");
-	wrapper::AddCheat<Cmd_BXT_CH_GoCheck, Handler<>>("bxt_ch_gocheck");
+	wrapper::AddCheat<Cmd_BXT_CH_CheckPoint_Create, Handler<>>("bxt_ch_checkpoint_create");
+	wrapper::AddCheat<Cmd_BXT_CH_CheckPoint_GoTo, Handler<>>("bxt_ch_checkpoint_goto");
 	wrapper::Add<
 		Cmd_BXT_Set_Angles,
 		Handler<float, float>,

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3259,8 +3259,8 @@ struct HwDLL::Cmd_BXT_CH_GoCheck
 		cl.pEngfuncs->SetViewAngles(hw.ch_checkpoint_viewangles);
 
 		if (hw.ch_checkpoint_is_duck) {
-			pl->v.flags |= 1 << 14;
-			pl->v.button |= 1 << 2;
+			pl->v.flags |= FL_DUCKING;
+			pl->v.button |= IN_DUCK;
 		}
 
 		// not moving after go check
@@ -3270,8 +3270,11 @@ struct HwDLL::Cmd_BXT_CH_GoCheck
 			pl->v.velocity = hw.ch_checkpoint_vel;
 
 		pl->v.origin = hw.ch_checkpoint_origin;
+
 		// for CS 1.6 stamina reset
-		pl->v.fuser2 = 0;
+		static bool is_cstrike = cl.DoesGameDirMatch("cstrike");
+		if (is_cstrike) 
+			pl->v.fuser2 = 0;
 	}
 };
 

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3266,6 +3266,9 @@ struct HwDLL::Cmd_BXT_CH_GoCheck
 		// not moving after go check
 		pl->v.velocity = Vector(0, 0, 0);
 
+		// annoying punchangle
+		pl->v.punchangle = Vector(0, 0, 0);
+
 		if (CVars::bxt_ch_checkpoint_with_vel.GetBool())
 			pl->v.velocity = hw.ch_checkpoint_vel;
 

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -796,6 +796,8 @@ void HwDLL::Clear()
 	libTASExportFile.close();
 	ch_hook = false;
 	ch_hook_point = Vector();
+	ch_checkpoint_is_set = false;
+	ch_checkpoint_is_duck = false;
 
 
 	tas_editor_mode = TASEditorMode::DISABLED;
@@ -3200,6 +3202,79 @@ void HwDLL::ChHookPlayer() {
 	pl->v.velocity = target;
 }
 
+struct HwDLL::Cmd_BXT_CH_CheckPoint
+{
+	NO_USAGE();
+
+	static void handler()
+	{
+		auto &hw = HwDLL::GetInstance();
+
+		auto pl = hw.GetPlayerEdict();
+
+		if (!pl)
+			return;
+
+		auto is_duck = pl->v.button & (IN_DUCK) || pl->v.flags & (FL_DUCKING);
+
+		if (CVars::bxt_ch_checkpoint_onground_only.GetBool() && !(pl->v.flags & (FL_ONGROUND))) {
+			auto is_ladder = pl->v.movetype == MOVETYPE_FLY;
+
+			auto origin_z_offset = pl->v.origin + Vector(0, 0, -2);
+			auto tr = hw.PlayerTrace(pl->v.origin, 
+				origin_z_offset, is_duck ? HLStrafe::HullType::DUCKED : HLStrafe::HullType::NORMAL, 0);
+
+			auto is_slide = tr.PlaneNormal[2] < (1 / std::sqrt(2)) && 0.f < tr.PlaneNormal[2];
+
+			if (!(is_ladder || is_slide))
+				return;
+		}
+
+		hw.ch_checkpoint_is_set = true;
+		hw.ch_checkpoint_origin = pl->v.origin;
+		hw.ch_checkpoint_vel = pl->v.velocity;
+		hw.ch_checkpoint_viewangles = pl->v.v_angle;
+		hw.ch_checkpoint_is_duck = is_duck;
+	}
+};
+
+struct HwDLL::Cmd_BXT_CH_GoCheck
+{
+	NO_USAGE();
+
+	static void handler()
+	{
+		auto &hw = HwDLL::GetInstance();
+
+		if (!hw.ch_checkpoint_is_set)
+			return;
+
+		auto &cl = ClientDLL::GetInstance();
+
+		auto pl = hw.GetPlayerEdict();
+
+		if (!pl)
+			return;
+
+		cl.pEngfuncs->SetViewAngles(hw.ch_checkpoint_viewangles);
+
+		if (hw.ch_checkpoint_is_duck) {
+			pl->v.flags |= 1 << 14;
+			pl->v.button |= 1 << 2;
+		}
+
+		// not moving after go check
+		pl->v.velocity = Vector(0, 0, 0);
+
+		if (CVars::bxt_ch_checkpoint_with_vel.GetBool())
+			pl->v.velocity = hw.ch_checkpoint_vel;
+
+		pl->v.origin = hw.ch_checkpoint_origin;
+		// for CS 1.6 stamina reset
+		pl->v.fuser2 = 0;
+	}
+};
+
 struct HwDLL::Cmd_BXT_CH_Get_Other_Player_Info
 {
 	NO_USAGE();
@@ -5224,6 +5299,8 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_tas_ducktap_priority);
 	RegisterCVar(CVars::bxt_ch_hook_speed);
 	RegisterCVar(CVars::bxt_allow_keypresses_in_demo);
+	RegisterCVar(CVars::bxt_ch_checkpoint_with_vel);
+	RegisterCVar(CVars::bxt_ch_checkpoint_onground_only);
 
 	if (ORIG_R_SetFrustum && scr_fov_value)
 	{
@@ -5280,6 +5357,8 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 		Handler<float, float, float>>("bxt_ch_set_vel_angles");
 	wrapper::AddCheat<Cmd_Plus_BXT_CH_Hook, Handler<>, Handler<int>>("+bxt_ch_hook");
 	wrapper::AddCheat<Cmd_Minus_BXT_CH_Hook, Handler<>, Handler<int>>("-bxt_ch_hook");
+	wrapper::AddCheat<Cmd_BXT_CH_CheckPoint, Handler<>>("bxt_ch_checkpoint");
+	wrapper::AddCheat<Cmd_BXT_CH_GoCheck, Handler<>>("bxt_ch_gocheck");
 	wrapper::Add<
 		Cmd_BXT_Set_Angles,
 		Handler<float, float>,
@@ -6417,8 +6496,10 @@ HOOK_DEF_0(HwDLL, void, __cdecl, Cbuf_Execute)
 		pauseOnTheFirstFrame = true;
 	}
 
-	if (*state != 5 && *state != 4)
+	if (*state != 5 && *state != 4) {
 		executing = false;
+		ch_checkpoint_is_set = false;
+	}
 
 	insideCbuf_Execute = true;
 	ORIG_Cbuf_Execute(); // executing might change inside if we had some kind of load command in the buffer.

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -518,8 +518,8 @@ protected:
 	struct Cmd_BXT_Splits_Place_Down;
 	struct Cmd_Plus_BXT_CH_Hook;
 	struct Cmd_Minus_BXT_CH_Hook;
-	struct Cmd_BXT_CH_CheckPoint;
-	struct Cmd_BXT_CH_GoCheck;
+	struct Cmd_BXT_CH_CheckPoint_Create;
+	struct Cmd_BXT_CH_CheckPoint_GoTo;
 
 	void RegisterCVarsAndCommandsIfNeeded();
 	void InsertCommands();

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -518,6 +518,8 @@ protected:
 	struct Cmd_BXT_Splits_Place_Down;
 	struct Cmd_Plus_BXT_CH_Hook;
 	struct Cmd_Minus_BXT_CH_Hook;
+	struct Cmd_BXT_CH_CheckPoint;
+	struct Cmd_BXT_CH_GoCheck;
 
 	void RegisterCVarsAndCommandsIfNeeded();
 	void InsertCommands();
@@ -758,4 +760,11 @@ protected:
 	Vector ch_hook_point;
 	void ChHookPlayer();
 	float ch_hook_hp_before;
+
+protected:
+	bool ch_checkpoint_is_set;
+	Vector ch_checkpoint_origin;
+	Vector ch_checkpoint_vel;
+	Vector ch_checkpoint_viewangles;
+	bool ch_checkpoint_is_duck;
 };


### PR DESCRIPTION
This is some of the stuffs that AmxModX KZ plugins have. I am on Lenix is very hard to hook up AmxModX plugins and do things in LAN servers (which is not any easier on Windows Half-Life with BXT). So I am trying to port more things I find useful here.

This is nice because I can do check point and go check for practicing/testing things. 

I did plan to have it with un-gocheck and un-checkpoint but I think it isn't very needed because you can just noclip with cheat.