### PR TITLE
HLSDK10_BUILD: align of some needed structures

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -877,7 +877,7 @@ void HwDLL::FindStuff()
 		} else
 			EngineDevWarning("[hw dll] Could not find sv.\n");
 
-		svs = reinterpret_cast<svs_t*>(MemUtils::GetSymbolAddress(m_Handle, "svs"));
+		svs = reinterpret_cast<server_static_t*>(MemUtils::GetSymbolAddress(m_Handle, "svs"));
 		if (svs) {
 			EngineDevMsg("[hw dll] Found svs at %p.\n", svs);
 			offEdict = 0x4a84;
@@ -1643,7 +1643,7 @@ void HwDLL::FindStuff()
 						);
 					pcl = reinterpret_cast<void*>(*reinterpret_cast<uintptr_t*>(f + 86) - 0x2AF80);
 					cls = *reinterpret_cast<void**>(f + 69);
-					svs = reinterpret_cast<svs_t*>(*reinterpret_cast<uintptr_t*>(f + 45) - 8);
+					svs = reinterpret_cast<server_static_t*>(*reinterpret_cast<uintptr_t*>(f + 45) - 8);
 					offEdict = *reinterpret_cast<ptrdiff_t*>(f + 122);
 					break;
 				case 1: // CoF-5936
@@ -1660,7 +1660,7 @@ void HwDLL::FindStuff()
 						);
 					pcl = reinterpret_cast<void*>(*reinterpret_cast<uintptr_t*>(f + 140) - 0x3BF88);
 					cls = *reinterpret_cast<void**>(f + 105);
-					svs = reinterpret_cast<svs_t*>(*reinterpret_cast<uintptr_t*>(f + 79) - 8);
+					svs = reinterpret_cast<server_static_t*>(*reinterpret_cast<uintptr_t*>(f + 79) - 8);
 					offEdict = *reinterpret_cast<ptrdiff_t*>(f + 182);
 					cofSaveHack = *reinterpret_cast<qboolean**>(f + 21);
 					is_cof_steam = true;
@@ -5384,7 +5384,7 @@ void HwDLL::InsertCommands()
 
 				resulting_frame.SetRepeats(1);
 
-				if (svs->num_clients >= 1) {
+				if (svs->maxclients >= 1) {
 					edict_t *pl = GetPlayerEdict();
 					if (pl) {
 						player.Origin[0] = pl->v.origin[0];
@@ -6047,7 +6047,7 @@ void HwDLL::InsertCommands()
 
 		// Manual autofuncs.
 		if (autojump || ducktap || jumpbug) {
-			if (svs->num_clients >= 1) {
+			if (svs->maxclients >= 1) {
 				edict_t *pl = GetPlayerEdict();
 				if (pl) {
 					player.Origin[0] = pl->v.origin[0];
@@ -6283,7 +6283,7 @@ HLStrafe::MovementVars HwDLL::GetMovementVars()
 	if (!is_cstrike && !is_czero && !is_tfc)
 		vars.UseSlow = true;
 
-	if (svs->num_clients >= 1) {
+	if (svs->maxclients >= 1) {
 		edict_t *pl = GetPlayerEdict();
 		if (pl) {
 			vars.EntFriction = pl->v.friction;
@@ -6625,7 +6625,7 @@ void HwDLL::SetPlayerVelocity(float velocity[3])
 
 bool HwDLL::TryGettingAccurateInfo(float origin[3], float velocity[3], float& health, float& armorvalue, int& waterlevel, float& stamina)
 {
-	if (!svs || svs->num_clients < 1)
+	if (!svs || svs->maxclients < 1)
 		return false;
 
 	edict_t *pl = GetPlayerEdict();
@@ -6676,7 +6676,7 @@ HLStrafe::TraceResult HwDLL::CameraTrace(float max_distance)
 }
 
 void HwDLL::StartTracing(bool extendDistanceLimit) {
-	if (!ORIG_PM_PlayerTrace || svs->num_clients < 1) {
+	if (!ORIG_PM_PlayerTrace || svs->maxclients < 1) {
 		return;
 	}
 
@@ -6696,7 +6696,7 @@ void HwDLL::StartTracing(bool extendDistanceLimit) {
 }
 
 void HwDLL::StopTracing() {
-	if (!ORIG_PM_PlayerTrace || svs->num_clients < 1) {
+	if (!ORIG_PM_PlayerTrace || svs->maxclients < 1) {
 		return;
 	}
 
@@ -6708,7 +6708,7 @@ void HwDLL::StopTracing() {
 HLStrafe::TraceResult HwDLL::UnsafePlayerTrace(const float start[3], const float end[3], HLStrafe::HullType hull) {
 	auto tr = HLStrafe::TraceResult{};
 
-	if (!ORIG_PM_PlayerTrace || svs->num_clients < 1) {
+	if (!ORIG_PM_PlayerTrace || svs->maxclients < 1) {
 		tr.Fraction = 1.f;
 		tr.EndPos[0] = end[0];
 		tr.EndPos[1] = end[1];
@@ -6777,7 +6777,7 @@ void HwDLL::SaveInitialDataToDemo()
 
 void HwDLL::UpdateCustomTriggersAndSplits()
 {
-	if (!svs || svs->num_clients < 1)
+	if (!svs || svs->maxclients < 1)
 		return;
 
 	edict_t *pl = GetPlayerEdict();

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -93,11 +93,11 @@ class HwDLL : public IHookableNameFilterOrdered
 		unsigned cursize;
 	};
 
-	struct svs_t
+	struct server_static_t
 	{
-		char unk[4];
+		int dll_initialized;
 		client_t *clients;
-		int num_clients;
+		int maxclients;
 	};
 
 	struct Key
@@ -216,7 +216,7 @@ public:
 		return *reinterpret_cast<double *>(reinterpret_cast<uintptr_t>(psv) + offTime);
 	}
 	inline edict_t* GetPlayerEdict() const {
-		if (!svs || svs->num_clients == 0)
+		if (!svs || svs->maxclients == 0)
 			return nullptr;
 
 		return *reinterpret_cast<edict_t**>(reinterpret_cast<uintptr_t>(svs->clients) + offEdict);
@@ -551,7 +551,7 @@ protected:
 	ptrdiff_t offNumEdicts;
 	ptrdiff_t offMaxEdicts;
 	ptrdiff_t offEdicts;
-	svs_t *svs;
+	server_static_t *svs;
 	ptrdiff_t offEdict;
 	void *svmove;
 	void **ppmove;

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -93,12 +93,21 @@ class HwDLL : public IHookableNameFilterOrdered
 		unsigned cursize;
 	};
 
+	#ifdef HLSDK10_BUILD
+	struct server_static_t
+	{
+		int maxclients;
+		byte align[28684];
+		client_t *clients;
+	};
+	#else
 	struct server_static_t
 	{
 		int dll_initialized;
 		client_t *clients;
 		int maxclients;
 	};
+	#endif
 
 	struct Key
 	{

--- a/HLSDK/common/cl_entity.h
+++ b/HLSDK/common/cl_entity.h
@@ -68,6 +68,11 @@ typedef struct cl_entity_s cl_entity_t;
 #include "entity_state.h"
 #endif
 
+/*
+	Size of 'cl_entity_t' in HLSDK 1.0 is 0x1A0 (416)
+	Size of 'cl_entity_t' in HLSDK 2.0 is 0xBB8 (3000)
+	Size of 'cl_entity_t' in James Bond 007: Nightfire (PC) is 0xD08 (3336)
+*/
 
 struct cl_entity_s
 {

--- a/HLSDK/common/entity_state.h
+++ b/HLSDK/common/entity_state.h
@@ -26,6 +26,13 @@
 //  entities that is sent to a client.
 typedef struct entity_state_s entity_state_t;
 
+/*
+	Size of 'entity_state_t' in HLSDK 1.0 [Day One - WON 1.0.0.8] is 0x8C (140)
+	Size of 'entity_state_t' in HLSDK 1.0 [WON 1.0.0.9 - 1.0.1.6] is 0x90 (144)
+	Size of 'entity_state_t' in HLSDK 2.0 is 0x154 (340)
+	Size of 'entity_state_t' in James Bond 007: Nightfire [PC] is 0x160 (352)
+*/
+
 struct entity_state_s
 {
 // Fields which are filled in by routines outside of delta compression

--- a/HLSDK/common/entity_state.h
+++ b/HLSDK/common/entity_state.h
@@ -33,6 +33,49 @@ typedef struct entity_state_s entity_state_t;
 	Size of 'entity_state_t' in James Bond 007: Nightfire [PC] is 0x160 (352)
 */
 
+#ifdef HLSDK10_BUILD
+struct entity_state_s
+{
+	int     entityType;  // Normal or Custom to know how to parse the entity.
+	int     number;      // Index into cl_entities array for this entity.
+	int     flags;       // The delta compression bit header.
+
+	vec3_t	origin;
+	vec3_t	angles;
+
+	int		modelindex;
+	int		sequence;
+	float	frame;
+	int		colormap;
+	short	skin;
+	short	solid;
+	int		effects;
+	float	scale;
+	
+	// render information
+	int		rendermode;
+	int		renderamt;
+	color24	rendercolor;
+	int		renderfx;
+
+	// Added for entity delta compression
+	//vec3_t  msg_origins[2];
+	//vec3_t  msg_angles[2];
+
+	int     movetype;
+	float   animtime;
+	float   framerate;
+	int     body;
+	byte    controller[4];
+	byte    blending[4];
+	vec3_t	velocity;
+
+	vec3_t  mins;    // Send bbox down to client for use during prediction.
+	vec3_t  maxs;
+
+	int		aiment;
+};
+#else
 struct entity_state_s
 {
 // Fields which are filled in by routines outside of delta compression
@@ -128,6 +171,7 @@ struct entity_state_s
 	vec3_t		vuser3;
 	vec3_t		vuser4;
 };
+#endif
 
 #define MAX_PHYSINFO_STRING 256
 typedef struct clientdata_s

--- a/HLSDK/engine/edict.h
+++ b/HLSDK/engine/edict.h
@@ -14,6 +14,13 @@
 
 #include "progdefs.h"
 
+/*
+	Size of 'edict_t' in HLSDK 1.0 is 0x2C8 (712)
+	Size of 'edict_t' in HLSDK 2.0, Sven Co-op is 0x324 (804)
+	Size of 'edict_t' in Cry of Fear [Steam] is 0x32C (812)
+	Size of 'edict_t' in James Bond 007: Nightfire [PC] is 0x3E0 (992)
+*/
+
 struct edict_s
 {
 	qboolean	free;

--- a/HLSDK/engine/edict.h
+++ b/HLSDK/engine/edict.h
@@ -10,9 +10,15 @@
 #ifdef _WIN32
 #pragma once
 #endif
+
+#ifdef HLSDK10_BUILD
+#define	MAX_ENT_LEAFS	24
+#else
 #define	MAX_ENT_LEAFS	48
+#endif
 
 #include "progdefs.h"
+#include "../common/entity_state.h"
 
 /*
 	Size of 'edict_t' in HLSDK 1.0 is 0x2C8 (712)
@@ -26,10 +32,17 @@ struct edict_s
 	qboolean	free;
 	int			serialnumber;
 	link_t		area;				// linked to a division node or leaf
-	
+
+	#ifndef HLSDK10_BUILD
 	int			headnode;			// -1 to use normal leaf check
+	#endif
+
 	int			num_leafs;
 	short		leafnums[MAX_ENT_LEAFS];
+
+	#ifdef HLSDK10_BUILD
+	entity_state_t	baseline;
+	#endif
 
 	float		freetime;			// sv.time when the object was freed
 

--- a/HLSDK/engine/progdefs.h
+++ b/HLSDK/engine/progdefs.h
@@ -80,11 +80,13 @@ typedef struct entvars_s
 	vec3_t		punchangle;		// auto-decaying view angle adjustment
 	vec3_t		v_angle;		// Viewing angle (player only)
 
+	#ifndef HLSDK10_BUILD
 	// For parametric entities
 	vec3_t		endpos;
 	vec3_t		startpos;
 	float		impacttime;
 	float		starttime;
+	#endif
 
 	int			fixangle;		// 0:nothing, 1:force view angles, 2:add avelocity
 	float		idealpitch;
@@ -191,6 +193,7 @@ typedef struct entvars_s
 	
 	edict_t		*pContainingEntity;
 
+	#ifndef HLSDK10_BUILD
 	int			playerclass;
 	float		maxspeed;
 
@@ -229,6 +232,7 @@ typedef struct entvars_s
 	edict_t		*euser2;
 	edict_t		*euser3;
 	edict_t		*euser4;
+	#endif
 
 	#ifdef COF_BUILD
 	byte		cof_unknown2[4];

--- a/HLSDK/engine/progdefs.h
+++ b/HLSDK/engine/progdefs.h
@@ -54,6 +54,13 @@ typedef struct
 	vec3_t		vecLandmarkOffset;
 } globalvars_t;
 
+/*
+	Size of 'entvars_t' in HLSDK 1.0 [Day One - WON 1.0.0.8] is 0x1F0 (496)
+	Size of 'entvars_t' in HLSDK 1.0 [WON 1.0.0.9 - 1.0.1.6] is 0x1EC (492)
+	Size of 'entvars_t' in HLSDK 2.0, Sven Co-op is 0x2A4 (676)
+	Size of 'entvars_t' in Cry of Fear [Steam] is 0x2AC (684)
+	Size of 'entvars_t' in James Bond 007: Nightfire [PC] is 0x2C0 (704)
+*/
 
 typedef struct entvars_s
 {
@@ -113,7 +120,7 @@ typedef struct entvars_s
 	int			light_level;
 
 	#ifdef COF_BUILD
-	byte		unknown[4];
+	byte		cof_unknown[4];
 	#endif
 
 	int			sequence;		// animation sequence
@@ -224,8 +231,7 @@ typedef struct entvars_s
 	edict_t		*euser4;
 
 	#ifdef COF_BUILD
-	byte		unknown2[4];	// actual location unknown, required for pointer arithmetic
-								// to work when we iterate through edicts.
+	byte		cof_unknown2[4];
 	#endif
 } entvars_t;
 


### PR DESCRIPTION
1) `entity_state_t`, `entvars_t` and `edict_t` is brought from [HLSDK 1.0 source code](https://github.com/a1batross/HLSDK_ancient/tree/master) (this is not a RE project, it just simply uploaded HLSDK 1.0 on GitHub)
Note: `EDICT.H` in repository is incorrect, the true `edict_t` structure in `PROGS.H` file

2) HLSDK 1.0 source code is only compatible with WON versions from 1.0.0.9 to 1.0.1.6
Half-Life: Day One, WON 1.0.0.8 or older requires the some reverse-engineering structs and interface versions to be compatible too

I used `sizeof` for those structures and compared their size to what old engine's uses in fact and I was able to confirm this thanks to the fact that I searched the engine and found some functions that actually call the size of the needed structures and it's equals

Also selectively took several variables from the structure to see what their offset was and compare it with engine references, and this also equals

Sources of where to find size of structures from those changes in engine:

## cl_entity_t

Search for `CL_EntityNum: %i is an invalid number, cl.max_edicts is %i` string to find **CL_EntityNum** function

## edict_t

Search for `NUM_FOR_EDICT: bad pointer` string to find **NUM_FOR_EDICT** function

## entvars_t

In HLSDK 2.0 version of engine, it could be found at the start of `ED_ParseEdict` function (in last argument of called **Q_memset**) 
**ED_ParseEdict** could be found from `Can't init %s` string

In older versions of engine, seems there is no references to `entvars_t` size, so, let's pretend and hope that in **edict_t** after `v` variable is nothing added

Then, we can to find the function, that calls some variable from `entvars_t` through the `edict_t` structure (example: `v.classname`)

Firstly, find the **iGetIndex** function from `globalname` string and see what offset of **classname** in that function (usually the offset is 0, unless something added at the start of **entvars_t**)
Then, find the **EntityInit** function from `Bad class!!` string and see what offset of **v.classname** in that function

Now, we doing the unga bunga math: `edict_t size - v.classname offset - classname offset = entvars_t size`
As said, that only works in case that there is not added variables after `v` in **edict_t** structure

## entity_state_t

Search for `Overflow beam entity list!` string to find **CL_LinkCustomEntity** function