### PR TITLE
HLSDK10_BUILD: used the right interface version and separated from unavailable functions

### DIFF
--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1253,16 +1253,19 @@ void ServerDLL::FindStuff()
 		ORIG_GetEntityAPI = reinterpret_cast<_GetEntityAPI>(MemUtils::GetSymbolAddress(m_Handle, "GetEntityAPI"));
 		if (ORIG_GetEntityAPI) {
 			DLL_FUNCTIONS funcs;
-			if (ORIG_GetEntityAPI(&funcs, 140)) {
+			if (ORIG_GetEntityAPI(&funcs, INTERFACE_VERSION)) {
 				// Gets our hooked addresses on Windows.
 				ORIG_ClientCommand = funcs.pfnClientCommand;
-				ORIG_PM_Move = funcs.pfnPM_Move;
-				ORIG_AddToFullPack = funcs.pfnAddToFullPack;
-				ORIG_CmdStart = funcs.pfnCmdStart;
 				EngineDevMsg("[server dll] Found ClientCommand at %p.\n", ORIG_ClientCommand);
-				EngineDevMsg("[server dll] Found PM_Move at %p.\n", ORIG_PM_Move);
-				EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
-				EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
+				if (INTERFACE_VERSION == 140)
+				{
+					ORIG_PM_Move = funcs.pfnPM_Move;
+					ORIG_AddToFullPack = funcs.pfnAddToFullPack;
+					ORIG_CmdStart = funcs.pfnCmdStart;
+					EngineDevMsg("[server dll] Found PM_Move at %p.\n", ORIG_PM_Move);
+					EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
+					EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
+				}
 			} else {
 				EngineDevWarning("[server dll] Could not get the server DLL function table.\n");
 				EngineWarning("Serverside shared RNG manipulation and usercommand logging are not available.\n");

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1244,25 +1244,25 @@ void ServerDLL::FindStuff()
 	ORIG_ClientCommand = reinterpret_cast<_ClientCommand>(MemUtils::GetSymbolAddress(m_Handle, "_Z13ClientCommandP7edict_s"));
 	ORIG_PM_Move = reinterpret_cast<_PM_Move>(MemUtils::GetSymbolAddress(m_Handle, "PM_Move"));
 
-	if (ORIG_CmdStart && ORIG_AddToFullPack && ORIG_ClientCommand && ORIG_PM_Move) {
-		EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
-		EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
+	if (ORIG_ClientCommand && ORIG_PM_Move && ORIG_AddToFullPack && ORIG_CmdStart) {
 		EngineDevMsg("[server dll] Found ClientCommand at %p.\n", ORIG_ClientCommand);
 		EngineDevMsg("[server dll] Found PM_Move at %p.\n", ORIG_PM_Move);
+		EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
+		EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
 	} else {
 		ORIG_GetEntityAPI = reinterpret_cast<_GetEntityAPI>(MemUtils::GetSymbolAddress(m_Handle, "GetEntityAPI"));
 		if (ORIG_GetEntityAPI) {
 			DLL_FUNCTIONS funcs;
 			if (ORIG_GetEntityAPI(&funcs, 140)) {
 				// Gets our hooked addresses on Windows.
-				ORIG_CmdStart = funcs.pfnCmdStart;
-				ORIG_AddToFullPack = funcs.pfnAddToFullPack;
 				ORIG_ClientCommand = funcs.pfnClientCommand;
 				ORIG_PM_Move = funcs.pfnPM_Move;
-				EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
-				EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
+				ORIG_AddToFullPack = funcs.pfnAddToFullPack;
+				ORIG_CmdStart = funcs.pfnCmdStart;
 				EngineDevMsg("[server dll] Found ClientCommand at %p.\n", ORIG_ClientCommand);
 				EngineDevMsg("[server dll] Found PM_Move at %p.\n", ORIG_PM_Move);
+				EngineDevMsg("[server dll] Found AddToFullPack at %p.\n", ORIG_AddToFullPack);
+				EngineDevMsg("[server dll] Found CmdStart at %p.\n", ORIG_CmdStart);
 			} else {
 				EngineDevWarning("[server dll] Could not get the server DLL function table.\n");
 				EngineWarning("Serverside shared RNG manipulation and usercommand logging are not available.\n");

--- a/HLSDK/engine/cdll_int.h
+++ b/HLSDK/engine/cdll_int.h
@@ -314,7 +314,11 @@ typedef struct cl_enginefuncs_s
 #include "../common/in_buttons.h"
 #endif
 
+#ifdef HLSDK10_BUILD
+#define CLDLL_INTERFACE_VERSION		6
+#else
 #define CLDLL_INTERFACE_VERSION		7
+#endif
 
 extern void ClientDLL_Init( void ); // from cdll_int.c
 extern void ClientDLL_Shutdown( void );

--- a/HLSDK/engine/eiface.h
+++ b/HLSDK/engine/eiface.h
@@ -15,11 +15,11 @@
 #ifndef EIFACE_H
 #define EIFACE_H
 
-#ifdef HLDEMO_BUILD
-#define INTERFACE_VERSION       001
-#else  // !HLDEMO_BUILD, i.e., regular version of HL
+#ifdef HLSDK10_BUILD
+#define INTERFACE_VERSION		138
+#else
 #define INTERFACE_VERSION		140
-#endif // !HLDEMO_BUILD
+#endif
 
 #include <stdio.h>
 #include "custom.h"


### PR DESCRIPTION
`INTERFACE_VERSION` can be found in **GetEntityAPI** exported function: https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/cbase.cpp#L104

`CLDLL_INTERFACE_VERSION` can be found in **Initialize** exported function: https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/cl_dll/cdll_int.cpp#L151