### PR TITLE
Added bxt_allow_keypresses_in_demo

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -27,6 +27,7 @@
 	X(_bxt_save_runtime_data_in_demos, "1") \
 	X(_bxt_tas_script_generation, "1337") \
 	X(bxt_taslog_filename, "taslogger.log") \
+	X(bxt_allow_keypresses_in_demo, "0") \
 	X(bxt_autopause, "0") \
 	X(bxt_interprocess_enable, "0") \
 	X(bxt_shake_remove, "0") \

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -864,6 +864,7 @@ void HwDLL::FindStuff()
 		if (cls) {
 			EngineDevMsg("[hw dll] Found cls at %p.\n", cls);
 			demorecording = reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(cls) + 0x405c);
+			demoplayback = reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(cls) + 0x4060);
 		} else
 			EngineDevWarning("[hw dll] Could not find cls.\n");
 
@@ -1546,6 +1547,7 @@ void HwDLL::FindStuff()
 				}
 
 				demorecording = *reinterpret_cast<int**>(reinterpret_cast<uintptr_t>(ORIG_CL_Stop_f) + offset);
+				demoplayback = reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(demorecording) + 0x4);
 			});
 
 		void *SCR_DrawFPS;
@@ -2136,6 +2138,7 @@ void HwDLL::FindStuff()
 			if (ORIG_CL_Stop_f) {
 				EngineDevMsg("[hw dll] Found CL_Stop_f at %p (using the %s pattern).\n", ORIG_CL_Stop_f, pattern->name());
 				EngineDevMsg("[hw dll] Found demorecording at %p.\n", demorecording);
+				EngineDevMsg("[hw dll] Found demoplayback at %p.\n", demoplayback);
 			} else {
 				EngineDevWarning("[hw dll] Could not find CL_Stop_f.\n");
 				ORIG_Cbuf_Execute = nullptr;

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -5223,6 +5223,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	RegisterCVar(CVars::bxt_disable_particles);
 	RegisterCVar(CVars::bxt_tas_ducktap_priority);
 	RegisterCVar(CVars::bxt_ch_hook_speed);
+	RegisterCVar(CVars::bxt_allow_keypresses_in_demo);
 
 	if (ORIG_R_SetFrustum && scr_fov_value)
 	{
@@ -7191,11 +7192,22 @@ HOOK_DEF_1(HwDLL, void, __cdecl, Cmd_TokenizeString, char*, text)
 
 HOOK_DEF_2(HwDLL, void, __cdecl, Key_Event, int, key, int, down)
 {
+	bool demo_ret_bool = false;
+	int demo_ret_value = 0;
+
+	if (CVars::bxt_allow_keypresses_in_demo.GetBool() && demoplayback)
+	{
+		demo_ret_value = *demoplayback;
+		*demoplayback = 0;
+		demo_ret_bool = true;
+	}
+
 	insideKeyEvent = true;
-
 	ORIG_Key_Event(key, down);
-
 	insideKeyEvent = false;
+
+	if (demo_ret_bool)
+		*demoplayback = demo_ret_value;
 }
 
 HOOK_DEF_0(HwDLL, void, __cdecl, Cmd_Exec_f)

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -571,6 +571,7 @@ protected:
 	cmdbuf_t *cmd_text;
 	double *host_frametime;
 	int *demorecording;
+	int *demoplayback;
 	cmdalias_t* cmd_alias;
 	cvar_t **cvar_vars;
 	movevars_t *movevars;


### PR DESCRIPTION
Demonstration:

https://github.com/YaLTeR/BunnymodXT/assets/58108407/192a1367-ce16-46a5-82f2-aeeaa48aa1eb

By default, when you pressing the key, engine call the console and stop doing some cook with your key inputs:

```cpp
  if ((((cls.demoplayback != false) && (cls.spectator == false)) && (down != false)) &&
     ((consolekeys[key] != false && (key_dest == key_game)))) {
    Con_ToggleConsole_f();
    return;
  }
```