### PR TITLE
Added bxt_get_steamid_from_demo

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -1397,9 +1397,11 @@ void HwDLL::FindStuff()
 				default:
 				case 0: // HL-Steampipe
 					ClientDLL::GetInstance().pEngfuncs = *reinterpret_cast<cl_enginefunc_t**>(reinterpret_cast<uintptr_t>(ClientDLL_Init) + 181);
+					is_steamid_build = true;
 					break;
 				case 1: // HL-4554
 					ClientDLL::GetInstance().pEngfuncs = *reinterpret_cast<cl_enginefunc_t**>(reinterpret_cast<uintptr_t>(ClientDLL_Init) + 226);
+					is_steamid_build = true;
 					break;
 				case 2: // HL-NGHL
 					ClientDLL::GetInstance().pEngfuncs = *reinterpret_cast<cl_enginefunc_t**>(reinterpret_cast<uintptr_t>(ClientDLL_Init) + 203);
@@ -1409,6 +1411,7 @@ void HwDLL::FindStuff()
 					break;
 				case 4: // CoF-5936
 					ClientDLL::GetInstance().pEngfuncs = *reinterpret_cast<cl_enginefunc_t**>(reinterpret_cast<uintptr_t>(ClientDLL_Init) + 230);
+					is_steamid_build = true;
 					break;
 				}
 			});
@@ -3486,6 +3489,24 @@ struct HwDLL::Cmd_BXT_Get_Server_Time
 	}
 };
 
+struct HwDLL::Cmd_BXT_Get_SteamID_From_Demo
+{
+	NO_USAGE();
+
+	static void handler()
+	{
+		auto& hw = HwDLL::GetInstance();
+		auto& cl = ClientDLL::GetInstance();
+		if (hw.is_steamid_build && hw.IsPlayingbackDemo())
+		{
+			int player = cl.pEngfuncs->GetLocalPlayer()->index;
+			player_info_s* player_info = hw.pEngStudio->PlayerInfo(player - 1);
+
+			hw.ORIG_Con_Printf("Steam ID: %" PRIu64 "\n", player_info->m_nSteamID);
+		}
+	}
+};
+
 struct HwDLL::Cmd_BXT_TAS_Autojump_Down
 {
 	NO_USAGE();
@@ -5370,6 +5391,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 		Handler<float, float>,
 		Handler<float, float, float>>("bxt_set_angles");
 	wrapper::Add<Cmd_BXT_Get_Server_Time, Handler<>>("bxt_get_server_time");
+	wrapper::Add<Cmd_BXT_Get_SteamID_From_Demo, Handler<>>("bxt_get_steamid_from_demo");
 	wrapper::Add<
 		Cmd_Multiwait,
 		Handler<>,

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3502,7 +3502,15 @@ struct HwDLL::Cmd_BXT_Get_SteamID_From_Demo
 			int player = cl.pEngfuncs->GetLocalPlayer()->index;
 			player_info_s* player_info = hw.pEngStudio->PlayerInfo(player - 1);
 
-			hw.ORIG_Con_Printf("Steam ID: %" PRIu64 "\n", player_info->m_nSteamID);
+			const uint64 STEAMID64_CONST = 76561197960265728; // 0x110000100000000
+			const unsigned long STEAMID32 = static_cast<unsigned long>(player_info->m_nSteamID);
+			const uint64 STEAMID32_TO_64 = STEAMID64_CONST + STEAMID32;
+
+			hw.ORIG_Con_Printf("SteamID32: %" PRIu64 "\n", STEAMID32);
+
+			std::ostringstream ss;
+			ss << "SteamID64: " << STEAMID32_TO_64 << "\n";
+			hw.ORIG_Con_Printf(ss.str().c_str());
 		}
 	}
 };

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3502,9 +3502,9 @@ struct HwDLL::Cmd_BXT_Get_SteamID_From_Demo
 			int player = cl.pEngfuncs->GetLocalPlayer()->index;
 			player_info_s* player_info = hw.pEngStudio->PlayerInfo(player - 1);
 
-			const uint64 STEAMID64_CONST = 76561197960265728; // 0x110000100000000
+			const steamid_t STEAMID64_CONST = 76561197960265728; // 0x110000100000000
 			const unsigned long STEAMID32 = static_cast<unsigned long>(player_info->m_nSteamID);
-			const uint64 STEAMID32_TO_64 = STEAMID64_CONST + STEAMID32;
+			const steamid_t STEAMID32_TO_64 = STEAMID64_CONST + STEAMID32;
 
 			hw.ORIG_Con_Printf("SteamID32: %" PRIu64 "\n", STEAMID32);
 

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -219,6 +219,7 @@ public:
 	inline bool IsActive() { return (psv && *reinterpret_cast<int*>(psv)); }
 
 	inline bool IsRecordingDemo() const { return demorecording && *demorecording == 1; }
+	inline bool IsPlayingbackDemo() const { return demoplayback && *demoplayback == 1; }
 	void StoreCommand(const char* command);
 
 	inline double GetTime() const {
@@ -352,6 +353,12 @@ public:
 
 	bool Called_Timer = false;
 
+	#ifdef _WIN32
+	bool is_steamid_build = false;
+	#else
+	bool is_steamid_build = true;
+	#endif
+
 	bool is_cof_steam = false; // Cry of Fear-specific
 
 	int CallOnTASPlaybackFrame();
@@ -436,6 +443,7 @@ protected:
 	struct Cmd_BXT_CH_Monster_Set_Origin;
 	struct Cmd_BXT_Get_Origin_And_Angles;
 	struct Cmd_BXT_Get_Server_Time;
+	struct Cmd_BXT_Get_SteamID_From_Demo;
 	struct Cmd_Multiwait;
 	struct Cmd_BXT_Camera_Fixed;
 	struct Cmd_BXT_Camera_Clear;

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -7,10 +7,12 @@
 #define _USE_MATH_DEFINES
 #include <Windows.h>
 #include <process.h>
+typedef unsigned __int64 uint64;
 #else
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <mqueue.h>
+typedef unsigned long long uint64;
 #endif
 
 #if defined(__GNUC__)

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -7,12 +7,12 @@
 #define _USE_MATH_DEFINES
 #include <Windows.h>
 #include <process.h>
-typedef unsigned __int64 uint64;
+typedef unsigned __int64 steamid_t;
 #else
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <mqueue.h>
-typedef unsigned long long uint64;
+typedef unsigned long long steamid_t;
 #endif
 
 #if defined(__GNUC__)

--- a/HLSDK/common/com_model.h
+++ b/HLSDK/common/com_model.h
@@ -420,6 +420,10 @@ typedef struct player_info_s
 	vec3_t	prevgaitorigin;
 
 	customization_t customdata;
+
+	char	hashedcdkey[16];
+
+	uint64	m_nSteamID;
 } player_info_t;
 
 #endif // #define COM_MODEL_H

--- a/HLSDK/common/com_model.h
+++ b/HLSDK/common/com_model.h
@@ -423,7 +423,7 @@ typedef struct player_info_s
 
 	char	hashedcdkey[16];
 
-	uint64	m_nSteamID;
+	steamid_t	m_nSteamID;
 } player_info_t;
 
 #endif // #define COM_MODEL_H

--- a/HLSDK/engine/cdll_int.h
+++ b/HLSDK/engine/cdll_int.h
@@ -105,6 +105,7 @@ typedef struct hud_player_info_s
 	short topcolor;
 	short bottomcolor;
 
+	uint64 m_nSteamID;
 } hud_player_info_t;
 
 

--- a/HLSDK/engine/cdll_int.h
+++ b/HLSDK/engine/cdll_int.h
@@ -105,7 +105,7 @@ typedef struct hud_player_info_s
 	short topcolor;
 	short bottomcolor;
 
-	uint64 m_nSteamID;
+	steamid_t m_nSteamID;
 } hud_player_info_t;
 
 


### PR DESCRIPTION
I know that there is `uint64_t`, but I decided to took from HLSDK to keep the same behaviour (for case if `uint64_t` is differs on some other platform and it will go for the fancy-schmancy stuff): https://github.com/ValveSoftware/halflife/blob/de70fada5061965884492178a7d6166646424a4e/public/steam/steamtypes.h

That `76561197960265728` const is not something that I got fantasied out of mind, most of Steam-related and demo parsing tools in fact uses the same *magic* number that is actually the starting ID