### PR TITLE
Added bxt_cof_allow_to_skip_all_cutscenes

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -90,7 +90,7 @@
 	X(bxt_cof_slowdown_if_use_on_ground, "0") \
 	X(bxt_cof_disable_monsters_teleport_to_spawn_after_load, "0") \
 	X(bxt_cof_disable_viewpunch_from_jump, "0") \
-	X(bxt_cof_allow_to_skip_all_cutscenes, "0") \
+	X(bxt_cof_allow_skipping_all_cutscenes, "0") \
 	X(cl_righthand, "0") \
 	X(bxt_remove_punchangles, "0") \
 	X(bxt_disable_brush_entities, "0") \

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -90,6 +90,7 @@
 	X(bxt_cof_slowdown_if_use_on_ground, "0") \
 	X(bxt_cof_disable_monsters_teleport_to_spawn_after_load, "0") \
 	X(bxt_cof_disable_viewpunch_from_jump, "0") \
+	X(bxt_cof_allow_to_skip_all_cutscenes, "0") \
 	X(cl_righthand, "0") \
 	X(bxt_remove_punchangles, "0") \
 	X(bxt_disable_brush_entities, "0") \

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -1626,7 +1626,7 @@ void ServerDLL::RegisterCVarsAndCommands()
 	if (ORIG_ShiftMonsters && is_cof)
 		REG(bxt_cof_disable_monsters_teleport_to_spawn_after_load);
 	if (ORIG_CTriggerCamera__FollowTarget && is_cof)
-		REG(bxt_cof_allow_to_skip_all_cutscenes);
+		REG(bxt_cof_allow_skipping_all_cutscenes);
 
 	REG(bxt_splits_print);
 	REG(bxt_splits_print_times_at_end);
@@ -2987,20 +2987,20 @@ HOOK_DEF_1(ServerDLL, void, __fastcall, CTriggerCamera__FollowTarget, void*, thi
 	entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4);
 	if (pev)
 	{
-		bool ret = false;
+		bool changed = false;
 		auto oldSpawnFlags = pev->spawnflags;
-		if (CVars::bxt_cof_allow_to_skip_all_cutscenes.GetBool())
+		if (CVars::bxt_cof_allow_skipping_all_cutscenes.GetBool())
 		{
 			if (pev->spawnflags & 1024) // "Unskippable" flag from .fgd
 			{
 				pev->spawnflags &= ~1024;
-				ret = true;
+				changed = true;
 			}
 		}
 
 		ORIG_CTriggerCamera__FollowTarget(thisptr);
 
-		if (ret)
+		if (changed)
 			pev->spawnflags = oldSpawnFlags;
 	}
 	else 

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -59,6 +59,7 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __cdecl, ShiftMonsters, Vector origin)
 	HOOK_DECL(void, __fastcall, CBasePlayer__ViewPunch, void* thisptr, int edx, float p, float y, float r)
 	HOOK_DECL(void, __fastcall, CBasePlayer__Jump, void* thisptr)
+	HOOK_DECL(void, __fastcall, CTriggerCamera__FollowTarget, void* thisptr)
 
 public:
 	static ServerDLL& GetInstance()


### PR DESCRIPTION
Quickly saying, in CoF it's possible to skip majority of cutscenes by simply holding the `ENTER` key (game is checking for `ENTER` key code in Windows API, and if so, it will speed up the game by set **host_framerate**)

But, there a only a like at least one cutscene that cannot be skippable (due of that mapper set a spawn flag for them), so runners does the set `host_framerate` manually instead! (funny and pity situation, when the game stop doing that - people start doing that themself)

So in the future, when leaderboard would switched to mandatory with BXT and rules adapted for that, it could be simply erase from that bad habit by enabling `bxt_cof_allow_skipping_all_cutscenes 1`

https://github.com/LogicAndTrick/sledge-formats/blob/05b3fcfb6261b956120e4d218e7a5a357e42ac51/Sledge.Formats.GameData.Tests/Resources/fgd/goldsource/cry-of-fear.fgd#L3720