### PR TITLE
Pattern-less implementation of GiveNamedItem function from HLSDK

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4785,19 +4785,16 @@ struct HwDLL::Cmd_BXT_Give
 
 	static void handler(const char *classname)
 	{
-		if (CVars::sv_cheats.GetBool())
-		{
-			auto &hw_dll = HwDLL::GetInstance();
-			auto &sv_dll = ServerDLL::GetInstance();
+		auto &hw_dll = HwDLL::GetInstance();
+		auto &sv_dll = ServerDLL::GetInstance();
 
-			void* classPtr = (*hw_dll.sv_player)->pvPrivateData;
-			uintptr_t thisAddr = reinterpret_cast<uintptr_t>(classPtr);
-			entvars_t *pev = *reinterpret_cast<entvars_t**>(thisAddr + 4);
+		void* classPtr = (*hw_dll.sv_player)->pvPrivateData;
+		uintptr_t thisAddr = reinterpret_cast<uintptr_t>(classPtr);
+		entvars_t *pev = *reinterpret_cast<entvars_t**>(thisAddr + 4);
 
-			int iszItem = sv_dll.pEngfuncs->pfnAllocString(classname); // Make a copy of the classname
+		int iszItem = sv_dll.pEngfuncs->pfnAllocString(classname); // Make a copy of the classname
 
-			sv_dll.GiveNamedItem(pev, iszItem);
-		}
+		sv_dll.GiveNamedItem(pev, iszItem);
 	}
 };
 
@@ -5668,7 +5665,7 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_TAS_Server_Send_Command, Handler<const char*>>("_bxt_tas_server_send_command");
 	wrapper::Add<Cmd_BXT_TAS_Client_Load_Received_Script, Handler<>>("_bxt_tas_client_load_received_script");
 
-	wrapper::Add<Cmd_BXT_Give, Handler<const char*>>("bxt_give");
+	wrapper::AddCheat<Cmd_BXT_Give, Handler<const char*>>("bxt_give");
 
 	wrapper::Add<Cmd_BXT_Show_Bullets_Clear, Handler<>>("bxt_show_bullets_clear");
 	wrapper::Add<Cmd_BXT_Show_Bullets_Enemy_Clear, Handler<>>("bxt_show_bullets_enemy_clear");

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4779,6 +4779,28 @@ struct HwDLL::Cmd_BXT_TAS_Client_Load_Received_Script
 	}
 };
 
+struct HwDLL::Cmd_BXT_Give
+{
+	USAGE("Usage: bxt_give <classname>\n");
+
+	static void handler(const char *classname)
+	{
+		if (CVars::sv_cheats.GetBool())
+		{
+			auto &hw_dll = HwDLL::GetInstance();
+			auto &sv_dll = ServerDLL::GetInstance();
+
+			void* classPtr = (*hw_dll.sv_player)->pvPrivateData;
+			uintptr_t thisAddr = reinterpret_cast<uintptr_t>(classPtr);
+			entvars_t *pev = *reinterpret_cast<entvars_t**>(thisAddr + 4);
+
+			int iszItem = sv_dll.pEngfuncs->pfnAllocString(classname); // Make a copy of the classname
+
+			sv_dll.GiveNamedItem(pev, iszItem);
+		}
+	}
+};
+
 struct HwDLL::Cmd_BXT_Show_Bullets_Clear
 {
 	NO_USAGE()
@@ -5645,6 +5667,8 @@ void HwDLL::RegisterCVarsAndCommandsIfNeeded()
 	wrapper::Add<Cmd_BXT_TAS_Become_Simulator_Client, Handler<>>("bxt_tas_become_simulator_client");
 	wrapper::Add<Cmd_BXT_TAS_Server_Send_Command, Handler<const char*>>("_bxt_tas_server_send_command");
 	wrapper::Add<Cmd_BXT_TAS_Client_Load_Received_Script, Handler<>>("_bxt_tas_client_load_received_script");
+
+	wrapper::Add<Cmd_BXT_Give, Handler<const char*>>("bxt_give");
 
 	wrapper::Add<Cmd_BXT_Show_Bullets_Clear, Handler<>>("bxt_show_bullets_clear");
 	wrapper::Add<Cmd_BXT_Show_Bullets_Enemy_Clear, Handler<>>("bxt_show_bullets_enemy_clear");

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -512,6 +512,7 @@ protected:
 	struct Cmd_BXT_TAS_Become_Simulator_Client;
 	struct Cmd_BXT_TAS_Server_Send_Command;
 	struct Cmd_BXT_TAS_Client_Load_Received_Script;
+	struct Cmd_BXT_Give;
 	struct Cmd_BXT_Show_Bullets_Clear;
 	struct Cmd_BXT_Show_Bullets_Enemy_Clear;
 	struct Cmd_BXT_Split;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -15,6 +15,8 @@
 #include "../splits.hpp"
 #include "../shared.hpp"
 
+#define ALERT(at, format, ...) pEngfuncs->pfnAlertMessage(at, const_cast<char*>(format), ##__VA_ARGS__)
+
 // Linux hooks.
 #ifndef _WIN32
 extern "C" void __cdecl _Z8CmdStartPK7edict_sPK9usercmd_sj(const edict_t* player, const usercmd_t* cmd, unsigned int random_seed)
@@ -1952,7 +1954,6 @@ HOOK_DEF_1(ServerDLL, void, __cdecl, PM_PlayerMove, qboolean, server)
 	if (CVars::bxt_force_duck.GetBool())
 		cmd->buttons |= IN_DUCK;
 
-	#define ALERT(at, format, ...) pEngfuncs->pfnAlertMessage(at, const_cast<char*>(format), ##__VA_ARGS__)
 	if (CVars::_bxt_taslog.GetBool() && pEngfuncs)
 	{
 		ALERT(at_console, "-- BXT TAS Log Start --\n");
@@ -1978,7 +1979,6 @@ HOOK_DEF_1(ServerDLL, void, __cdecl, PM_PlayerMove, qboolean, server)
 		ALERT(at_console, "New onground: %d; new usehull: %d\n", *groundEntity, *reinterpret_cast<int*>(pmove + 0xBC));
 		ALERT(at_console, "-- BXT TAS Log End --\n");
 	}
-	#undef ALERT
 
 	if (hwDLL.IsTASLogging()) {
 		LogPlayerMove(false, pmove);
@@ -2125,7 +2125,6 @@ HOOK_DEF_3(ServerDLL, void, __cdecl, CmdStart, const edict_t*, player, const use
 		hwDLL.logWriter.SetArmor(hwDLL.GetPlayerEdict()->v.armorvalue);
 	}
 
-	#define ALERT(at, format, ...) pEngfuncs->pfnAlertMessage(at, const_cast<char*>(format), ##__VA_ARGS__)
 	if (CVars::_bxt_taslog.GetBool() && pEngfuncs)
 	{
 		ALERT(at_console, "-- CmdStart Start --\n");
@@ -2137,7 +2136,6 @@ HOOK_DEF_3(ServerDLL, void, __cdecl, CmdStart, const edict_t*, player, const use
 		ALERT(at_console, "Paused: %s\n", (hwDLL.IsPaused() ? "true" : "false"));
 		ALERT(at_console, "-- CmdStart End --\n");
 	}
-	#undef ALERT
 
 	return ORIG_CmdStart(player, cmd, seed);
 }
@@ -2661,9 +2659,7 @@ void ServerDLL::GiveNamedItem(entvars_t *pev, int istr)
 		edict_t *pent = pEngfuncs->pfnCreateNamedEntity(istr);
 		if (!pent || !pEngfuncs->pfnEntOffsetOfPEntity(pent))
 		{
-			#define ALERT(at, format, ...) pEngfuncs->pfnAlertMessage(at, const_cast<char*>(format), ##__VA_ARGS__)
 			ALERT (at_console, "NULL Ent in GiveNamedItem!\n");
-			#undef ALERT
 			return;
 		}
 		pent->v.origin = pev->origin;
@@ -3353,3 +3349,5 @@ HOOK_DEF_1(ServerDLL, int, __cdecl, CBaseEntity__IsInWorld_Linux, void*, thisptr
 
 	return ORIG_CBaseEntity__IsInWorld_Linux(thisptr);
 }
+
+#undef ALERT

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -139,6 +139,11 @@ protected:
 	typedef void(__fastcall *_CoF_CBasePlayer__GiveNamedItem)(void *thisptr, int edx, const char *pszName, bool deletewhendropped);
 	_CoF_CBasePlayer__GiveNamedItem ORIG_CoF_CBasePlayer__GiveNamedItem;
 
+	typedef int(__cdecl *_DispatchSpawn)(edict_t *pent);
+	_DispatchSpawn ORIG_DispatchSpawn;
+	typedef void(__cdecl *_DispatchTouch)(edict_t *pentTouched, edict_t *pentOther);
+	_DispatchTouch ORIG_DispatchTouch;
+
 	typedef bool (__fastcall *_IsPlayer)(void *thisptr);
 	typedef void (__fastcall *_Center)(void *thisptr, int edx, Vector *center);
 
@@ -155,6 +160,8 @@ protected:
 
 	void DoWouldCrashMessage();
 	void CoFChanges();
+
+	void GiveNamedItem(entvars_t *pev, int istr);
 
 	void **ppmove;
 	ptrdiff_t offPlayerIndex;

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -113,6 +113,8 @@ public:
 	bool is_cof = false; // Cry of Fear-specific
 	ptrdiff_t offm_fStamina; // Cry of Fear-specific
 
+	void GiveNamedItem(entvars_t *pev, int istr);
+
 private:
 	ServerDLL() : IHookableDirFilter({ L"dlls", L"cl_dlls"}) {};
 	ServerDLL(const ServerDLL&);
@@ -132,12 +134,6 @@ protected:
 	_PM_Ladder ORIG_PM_Ladder;
 	typedef int(__cdecl *_CChangeLevel__InTransitionVolume)(void *pEntity, char *pVolumeName);
 	_CChangeLevel__InTransitionVolume ORIG_CChangeLevel__InTransitionVolume;
-	typedef void(__fastcall *_CBasePlayer__GiveNamedItem)(void *thisptr, int edx, const char *pszName);
-	_CBasePlayer__GiveNamedItem ORIG_CBasePlayer__GiveNamedItem;
-	typedef void(__cdecl *_CBasePlayer__GiveNamedItem_Linux)(void *thisptr, const char *pszName);
-	_CBasePlayer__GiveNamedItem_Linux ORIG_CBasePlayer__GiveNamedItem_Linux;
-	typedef void(__fastcall *_CoF_CBasePlayer__GiveNamedItem)(void *thisptr, int edx, const char *pszName, bool deletewhendropped);
-	_CoF_CBasePlayer__GiveNamedItem ORIG_CoF_CBasePlayer__GiveNamedItem;
 
 	typedef int(__cdecl *_DispatchSpawn)(edict_t *pent);
 	_DispatchSpawn ORIG_DispatchSpawn;
@@ -160,8 +156,6 @@ protected:
 
 	void DoWouldCrashMessage();
 	void CoFChanges();
-
-	void GiveNamedItem(entvars_t *pev, int istr);
 
 	void **ppmove;
 	ptrdiff_t offPlayerIndex;

--- a/BunnymodXT/patterns.hpp
+++ b/BunnymodXT/patterns.hpp
@@ -921,18 +921,6 @@ namespace patterns
 			"55 8B EC 81 EC BC 00 00 00 53 56 57 89 4D ?? 8B 45 ?? 0F B6 88"
 		);
 
-		PATTERNS(CBasePlayer__GiveNamedItem,
-			"CStrike-Latest",
-			"8B 44 24 ?? 56 57 8B F9 8B 0D ?? ?? ?? ?? 2B 81 ?? ?? ?? ?? 50 E8"
-		);
-
-		PATTERNS(CoF_CBasePlayer__GiveNamedItem,
-			"CoF-Mod-155",
-			"55 8B EC 83 EC 4C 53 56 57 89 4D ?? 83 7D ?? 00 74",
-			"CoF-5936",
-			"55 8B EC 53 8B 5D ?? 57 8B F9 85 DB 0F 84 ?? ?? ?? ?? BA"
-		);
-
 		PATTERNS(CPushable__Move,
 			"HL-SteamPipe",
 			"53 56 8B F1 8B 4C 24 0C 57 33 DB 8B 79 04 8B 87 A4 01 00 00 F6 C4 02 74 3A 8B 87 9C 01 00 00 85 C0 74 30 8D 90 80 00 00 00 8B 46 04",

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -55,6 +55,7 @@ using std::ptrdiff_t;
 #include <hlstrafe.hpp>
 
 #include "HLSDK/dlls/extdll.h"
+#include "HLSDK/dlls/cbase.h"
 #include "HLSDK/cl_dll/wrect.h"
 #include "HLSDK/cl_dll/hud.h"
 #include "HLSDK/common/ref_params.h"
@@ -80,16 +81,6 @@ typedef int(*pfnUserMsgHook)(const char *pszName, int iSize, void *pbuf);
 #ifndef M_PI
 const double M_PI = 3.14159265358979323846;
 #endif
-
-const unsigned FCAP_CUSTOMSAVE = 0x00000001;
-const unsigned FCAP_ACROSS_TRANSITION = 0x00000002;
-const unsigned FCAP_MUST_SPAWN = 0x00000004;
-const unsigned FCAP_DONT_SAVE = 0x80000000;
-const unsigned FCAP_IMPULSE_USE = 0x00000008;
-const unsigned FCAP_CONTINUOUS_USE = 0x00000010;
-const unsigned FCAP_ONOFF_USE = 0x00000020;
-const unsigned FCAP_DIRECTIONAL_USE = 0x00000040;
-const unsigned FCAP_MASTER = 0x00000080;
 
 /*
 	Declare a hook. Does the following:

--- a/HLSDK/common/const.h
+++ b/HLSDK/common/const.h
@@ -672,8 +672,6 @@
 #define TE_BOUNCE_SHELL		1
 #define TE_BOUNCE_SHOTSHELL	2
 
-#define	SF_NORESPAWN (1 << 30) // Smiley: This is taken from cbase.h in Half-Life SDK, but it's better to declare it here
-
 // Rendering constants
 enum 
 {	

--- a/HLSDK/common/const.h
+++ b/HLSDK/common/const.h
@@ -672,6 +672,8 @@
 #define TE_BOUNCE_SHELL		1
 #define TE_BOUNCE_SHOTSHELL	2
 
+#define	SF_NORESPAWN (1 << 30) // Smiley: This is taken from cbase.h in Half-Life SDK, but it's better to declare it here
+
 // Rendering constants
 enum 
 {	

--- a/HLSDK/dlls/cbase.h
+++ b/HLSDK/dlls/cbase.h
@@ -1,0 +1,51 @@
+/***
+*
+*	Copyright (c) 1996-2001, Valve LLC. All rights reserved.
+*	
+*	This product contains software technology licensed from Id 
+*	Software, Inc. ("Id Technology").  Id Technology (c) 1996 Id Software, Inc. 
+*	All Rights Reserved.
+*
+*   Use, distribution, and modification of this source code and/or resulting
+*   object code is restricted to non-commercial enhancements to products from
+*   Valve LLC.  All other use, distribution, or modification is prohibited
+*   without written permission from Valve LLC.
+*
+****/
+/*
+
+Class Hierachy
+
+CBaseEntity
+	CBaseDelay
+		CBaseToggle
+			CBaseItem
+			CBaseMonster
+				CBaseCycler
+				CBasePlayer
+				CBaseGroup
+*/
+
+#ifndef CBASE_H
+#define CBASE_H
+#ifdef _WIN32
+#pragma once
+#endif
+
+// These are caps bits to indicate what an object's capabilities (currently used for save/restore and level transitions)
+const unsigned FCAP_CUSTOMSAVE = 0x00000001;
+const unsigned FCAP_ACROSS_TRANSITION = 0x00000002;		// should transfer between transitions
+const unsigned FCAP_MUST_SPAWN = 0x00000004;		// Spawn after restore
+const unsigned FCAP_DONT_SAVE = 0x80000000;		// Don't save this
+const unsigned FCAP_IMPULSE_USE = 0x00000008;		// can be used by the player
+const unsigned FCAP_CONTINUOUS_USE = 0x00000010;		// can be used by the player
+const unsigned FCAP_ONOFF_USE = 0x00000020;		// can be used by the player
+const unsigned FCAP_DIRECTIONAL_USE = 0x00000040;		// Player sends +/- 1 when using (currently only tracktrains)
+const unsigned FCAP_MASTER = 0x00000080;		// Can be used to "master" other entities (like multisource)
+
+// UNDONE: This will ignore transition volumes (trigger_transition), but not the PVS!!!
+const unsigned FCAP_FORCE_TRANSITION = 0x00000080;		// ALWAYS goes across transitions
+
+#define	SF_NORESPAWN (1 << 30) // !!!set this bit on guns and stuff that should never respawn.
+
+#endif

--- a/HLSDK/dlls/cbase.h
+++ b/HLSDK/dlls/cbase.h
@@ -16,14 +16,20 @@
 
 Class Hierachy
 
-CBaseEntity
-	CBaseDelay
-		CBaseToggle
-			CBaseItem
-			CBaseMonster
-				CBaseCycler
-				CBasePlayer
-				CBaseGroup
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBasePlayerItem -> CBasePlayerWeapon
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseButton
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseDoor
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseMonster -> CBasePlayer
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseMonster -> CMonsterMaker
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseMonster -> CSquadMonster
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseMonster -> CTalkMonster
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CBaseTrigger -> CChangeLevel
+CBaseEntity -> CBaseDelay -> CBaseAnimating -> CBaseToggle -> CMultiManager
+CBaseEntity -> CBaseDelay -> CBreakable -> CPushable
+CBaseEntity -> CBaseDelay -> CTriggerRelay
+CBaseEntity -> CBasePlayerAmmo
+CBaseEntity -> CPointEntity -> CEnvGlobal
+CBaseEntity -> CPointEntity -> CMultiSource
 */
 
 #ifndef CBASE_H


### PR DESCRIPTION
That planned for partially support of the co-op, so that you can give the needed weapons to players without having to hook `GiveNamedItem` for the each specific mod

Code from HLSDK: https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/player.cpp#L3322

If you want to test, then for example you can add the following code to the **ClientCommand** function and then type `bxt_give weapon_shotgun` in console

```cpp
} else if ((std::strcmp(cmd, "bxt_give") == 0) && CVars::sv_cheats.GetBool()) {
		int iszItem = pEngfuncs->pfnAllocString(pEngfuncs->pfnCmd_Argv(1)); // Make a copy of the classname
		GiveNamedItem(pev, iszItem);
```