### PR TITLE
Inherit msurface_t for new structure due to added variable in the end with Half-Life 25th anniversary update

### DIFF
--- a/HLSDK/common/com_model.h
+++ b/HLSDK/common/com_model.h
@@ -272,6 +272,19 @@ struct msurface_s
 };
 #endif
 
+typedef struct displaylist_s // Half-Life 25th anniversary update (hardware engine)
+{
+	unsigned gl_displaylist;
+	int rendermode;
+	float scrolloffset;
+	int renderDetailTexture;
+} displaylist_t;
+
+struct msurface_hw_25th_anniversary_t : public msurface_t 
+{
+	displaylist_t displaylist; // Half-Life 25th anniversary update (hardware engine)
+};
+
 typedef struct
 {
 	int			planenum;


### PR DESCRIPTION
You can't just add it to the end of the current structure, because this will simply break compatibility with all previous versions of the engine when using data from `msurface_t` for BXT code

All you need is to say create a variable in the code, like: `bool is_hl25_update = false` and enable it if BXT detects that we definitely are playing on a new version of the engine

After it should be possible to use `reinterpret_cast` in places where that related code is used to keep compatibility for both versions