### PR TITLE
Removed GPL copyright from Quake for cmd.h

### DIFF
--- a/HLSDK/engine/cmd.h
+++ b/HLSDK/engine/cmd.h
@@ -1,18 +1,3 @@
-/*
-Copyright (C) 1996-1997 Id Software, Inc.
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-*/
-
 // cmd.h -- Command buffer and command execution
 
 //===========================================================================


### PR DESCRIPTION
🤫

But seriously speaking, the comments remaining in this header are also appear in the Source SDK code, so I think it fair to remove only the copyright

After all, in fact, this structure was is not full copy but a bit reversed from GoldSrc, example that `int flags;` in the end of **cmd_function_t** is not exist in header from Quake code, I got it added from decompiled linux goldsrc engine code