### PR TITLE
Add bxt_ch_trigger_tp_keeps_momentum

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -237,7 +237,11 @@
 	X(bxt_ch_checkpoint_onground_only, "0") \
 	X(bxt_ch_fix_sticky_slide, "0") \
 	X(bxt_ch_fix_sticky_slide_offset, "0.01") \
-	X(bxt_ch_noclip_speed, "0")
+	X(bxt_ch_noclip_speed, "0") \
+	X(bxt_ch_trigger_tp_keeps_momentum, "0") \
+	X(bxt_ch_trigger_tp_keeps_momentum_velocity, "1") \
+	X(bxt_ch_trigger_tp_keeps_momentum_velocity_redirect, "0") \
+	X(bxt_ch_trigger_tp_keeps_momentum_viewangles, "1")
 
 class CVarWrapper
 {

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -3430,7 +3430,10 @@ void TriggerTpKeepsMomentumRestore(Vector prev_vel, Vector prev_view, Vector pre
 	}
 
 	if (CVars::bxt_ch_trigger_tp_keeps_momentum_viewangles.GetBool()) {
-		pev->fixangle = 0; // cannot change angle if it is 1
+		// In HLSDK, due to some inheritance stuffs, pevToucher's viewangles is changed differently.
+		// In and only in TeleportTouch, pev->fixangle is set to 1.
+		// If not set back to 0, we cannot set our viewangles, due to inheritance stuffs.
+		pev->fixangle = 0;
 		pev->v_angle = prev_view;
 		pev->angles = prev_angles;
 	}

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -64,6 +64,8 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(void, __fastcall, CTriggerCamera__FollowTarget, void* thisptr)
 	HOOK_DECL(int, __fastcall, CBaseEntity__IsInWorld, void* thisptr)
 	HOOK_DECL(int, __cdecl, CBaseEntity__IsInWorld_Linux, void* thisptr)
+	HOOK_DECL(void, __fastcall, CBaseTrigger__TeleportTouch, void* thisptr, int edx, void* pOther)
+	HOOK_DECL(void, __cdecl, CBaseTrigger__TeleportTouch_Linux, void* thisptr, void* pOther)
 
 public:
 	static ServerDLL& GetInstance()
@@ -116,6 +118,8 @@ public:
 	ptrdiff_t offm_fStamina; // Cry of Fear-specific
 
 	void GiveNamedItem(entvars_t *pev, int istr);
+
+	bool IsPlayer(edict_t *ent);
 
 private:
 	ServerDLL() : IHookableDirFilter({ L"dlls", L"cl_dlls"}) {};


### PR DESCRIPTION
This is useful for some surf/bhop maps that take advantage of portal-like teleportation.

Implementation is simple because in order for it to work, the mapper has to make the map linear as well.

This case is promised to never happen.
![image](https://github.com/YaLTeR/BunnymodXT/assets/29143195/40b6a5da-181c-41ef-a904-bb53a8c33ee7)


~Waiting for CI to test on Windows.
Currently crashing on Windows.....~