### PR TITLE
Add bxt_ch_noclip_speed

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -236,7 +236,8 @@
 	X(bxt_ch_checkpoint_with_vel, "1") \
 	X(bxt_ch_checkpoint_onground_only, "0") \
 	X(bxt_ch_fix_sticky_slide, "0") \
-	X(bxt_ch_fix_sticky_slide_offset, "0.01")
+	X(bxt_ch_fix_sticky_slide_offset, "0.01") \
+	X(bxt_ch_noclip_speed, "0")
 
 class CVarWrapper
 {

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -174,6 +174,9 @@ protected:
 	ptrdiff_t offInDuck;
 	ptrdiff_t offFlags;
 	ptrdiff_t offBasevelocity;
+	ptrdiff_t offMaxspeed;
+	ptrdiff_t offClientMaxspeed;
+	ptrdiff_t offMoveType;
 
 	void *pGlobalState;
 
@@ -238,4 +241,7 @@ protected:
 
 	Vector cmdStartOrigin;
 	Vector cmdStartVelocity;
+
+	float ch_noclip_vel_prev_maxspeed;
+	float ch_noclip_vel_prev_clientmaxspeed;
 };


### PR DESCRIPTION
Closes #505 

By default noclip is now faster. I think it is nicer that it is faster now. Could be changed.

Also the speed here is just rough estimation because if player has very high forward/side/up speed, then they will go fast. What are the odds.

Might break existing Noclip% WR.