### PR TITLE
feature: landmark for trigger_teleport

### DIFF
--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -241,7 +241,8 @@
 	X(bxt_ch_trigger_tp_keeps_momentum, "0") \
 	X(bxt_ch_trigger_tp_keeps_momentum_velocity, "1") \
 	X(bxt_ch_trigger_tp_keeps_momentum_velocity_redirect, "0") \
-	X(bxt_ch_trigger_tp_keeps_momentum_viewangles, "1")
+	X(bxt_ch_trigger_tp_keeps_momentum_viewangles, "1") \
+	X(bxt_ch_trigger_tp_landmark, "0")
 
 class CVarWrapper
 {

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -7672,6 +7672,7 @@ HOOK_DEF_3(HwDLL, int, __cdecl, SV_SpawnServer, int, bIsDemo, char*, server, cha
 	if (ret) {
 		Interprocess::WriteMapChange(CustomHud::GetTime(), server);
 		lastLoadedMap = server;
+		ServerDLL::GetInstance().ClearTPLandmarks();
 	}
 
 	if (insideHost_Loadgame_f) {

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -7669,10 +7669,12 @@ HOOK_DEF_0(HwDLL, void, __cdecl, R_DrawSkyBox)
 HOOK_DEF_3(HwDLL, int, __cdecl, SV_SpawnServer, int, bIsDemo, char*, server, char*, startspot)
 {
 	auto ret = ORIG_SV_SpawnServer(bIsDemo, server, startspot);
+
+	ServerDLL::GetInstance().ClearTPLandmarks();
+
 	if (ret) {
 		Interprocess::WriteMapChange(CustomHud::GetTime(), server);
 		lastLoadedMap = server;
-		ServerDLL::GetInstance().ClearTPLandmarks();
 	}
 
 	if (insideHost_Loadgame_f) {

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -3504,7 +3504,7 @@ void TriggerTpLandmarkAfter(entvars_t *pev, Vector offset)
 {
 	pev->origin = pev->origin + offset;
 	// have to offset by some HULL because of origin z diff
-	const auto is_duck = pev->button & (IN_DUCK) || pev->flags & (FL_DUCKING);
+	const auto is_duck = pev->bInDuck || pev->flags & (FL_DUCKING);
 	const Vector VEC_HULL_MIN(-16, -16, -36);
 	const Vector VEC_DUCK_HULL_MIN(-16, -16, -18);
 	const auto hull_offset = is_duck ? VEC_DUCK_HULL_MIN : VEC_HULL_MIN;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -3505,8 +3505,6 @@ void TriggerTpLandmarkAfter(entvars_t *pev, Vector offset)
 	pev->origin = pev->origin + offset;
 	// have to offset by some HULL because of origin z diff
 	const auto is_duck = pev->bInDuck || pev->flags & (FL_DUCKING);
-	const Vector VEC_HULL_MIN(-16, -16, -36);
-	const Vector VEC_DUCK_HULL_MIN(-16, -16, -18);
 	const auto hull_offset = is_duck ? VEC_DUCK_HULL_MIN : VEC_HULL_MIN;
 
 	pev->origin[2] += hull_offset[2];

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -66,6 +66,7 @@ class ServerDLL : public IHookableDirFilter
 	HOOK_DECL(int, __cdecl, CBaseEntity__IsInWorld_Linux, void* thisptr)
 	HOOK_DECL(void, __fastcall, CBaseTrigger__TeleportTouch, void* thisptr, int edx, void* pOther)
 	HOOK_DECL(void, __cdecl, CBaseTrigger__TeleportTouch_Linux, void* thisptr, void* pOther)
+	HOOK_DECL(void, __cdecl, DispatchKeyValue, edict_t* pentKeyvalue, KeyValueData* pkvd)
 
 public:
 	static ServerDLL& GetInstance()
@@ -248,4 +249,8 @@ protected:
 
 	float ch_noclip_vel_prev_maxspeed;
 	float ch_noclip_vel_prev_clientmaxspeed;
+
+public:
+	std::unordered_map<int, std::string> tpLandmarks;
+	void ClearTPLandmarks();
 };


### PR DESCRIPTION
Something from CSS. Something like this https://github.com/s1lentq/ReGameDLL_CS/issues/950

~~I have to hijack the "message" field because `trigger_teleportation` does not have its own key value function.~~

~~I don't really hope this thing is merged but I want it stay around in case anyone wanting to test~~ landmark teleportation in GoldSrc. It is a neat feature, very simple and effective.

Here is the map to test, along with its source 
[arte_confused.zip](https://github.com/YaLTeR/BunnymodXT/files/14409237/arte_confused.zip)
