### PR TITLE
minor: runtime_data: declared checksums structure

### DIFF
--- a/BunnymodXT/runtime_data.cpp
+++ b/BunnymodXT/runtime_data.cpp
@@ -46,6 +46,7 @@ namespace RuntimeData
 			PLAYERHEALTH,
 			SPLIT_MARKER,
 			FLAGS,
+			CHECKSUMS,
 		};
 
 		// Encrypting filter.
@@ -367,6 +368,14 @@ namespace RuntimeData
 				archive(f.flags);
 			}
 
+			void operator()(const Checksums& c) const {
+				archive(RuntimeDataType::CHECKSUMS);
+
+				archive(c.client);
+				archive(c.server);
+				archive(c.map);
+			}
+
 		private:
 			Archive& archive;
 		};
@@ -489,6 +498,14 @@ namespace RuntimeData
 				data = f;
 				break;
 			}
+			case RuntimeDataType::CHECKSUMS: {
+				Checksums c;
+				archive(c.client);
+				archive(c.server);
+				archive(c.map);
+				data = c;
+				break;
+			}
 			default: {
 				EngineDevWarning("Read unknown RuntimeDataType %d\n", data_type);
 				break;
@@ -554,6 +571,7 @@ namespace RuntimeData
 		void operator()(const RuntimeData::Edicts& e) const {}
 		void operator()(const RuntimeData::SplitMarker& m) const {}
 		void operator()(const RuntimeData::Flags& f) const {}
+		void operator()(const RuntimeData::Checksums& c) const {}
 
 	private:
 		// bxt commands that should be executed when found during demo playback

--- a/BunnymodXT/runtime_data.hpp
+++ b/BunnymodXT/runtime_data.hpp
@@ -67,6 +67,12 @@ namespace RuntimeData
 		int flags;
 	};
 
+	struct Checksums {
+		std::string client;
+		std::string server;
+		std::string map;
+	};
+
 	using Data = boost::variant<VersionInfo,
 	                            CVarValues,
 	                            Time,
@@ -80,7 +86,8 @@ namespace RuntimeData
 	                            Edicts,
 	                            PlayerHealth,
 	                            SplitMarker,
-	                            Flags>;
+	                            Flags,
+	                            Checksums>;
 
 	void Add(Data data);
 	void Clear();


### PR DESCRIPTION
This request does NOT solve the issue, but simply gives it a some start in resolving.

Hashes will be transmitted as strings instead of the hardcoded amount of allocated bytes for them, just so that if something happens we can easily change the hashing algorithm without consequences for this.

On the parser side, we can always check whether the string contains any other characters other than a-F and 0-9 as validity (basically to make sure that this string corresponds to hexadecimal format)

And a simple way on the parser side to determine the type of algorithm is by the number of characters (e.g. MD5 is 128 bit = 128 / 8 = 16 * 2 = 32 characters); this is could be used for comparison with some hardcoded list of hashes in parser side

We also need to return at least the logging name of the server module later, since modules logging was removed with this commit: https://github.com/YaLTeR/BunnymodXT/commit/1d049ef9d06a97baf4c47c960c79cb8296cbaa4f

I also don’t see much point in logging the names of all loaded modules, but the name of the server module (`hl.dll` and etc) must be logged for the purpose to working with hardcoded list of hashes (e.g. since list might be formatted in way like: `"server_module_name", "md5_hash", "sha1_hash", "sha256_hash"`)