### PR TITLE
headers: HLSDK: server_static_t has been moved to a separately created header

### DIFF
--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -88,22 +88,6 @@ class HwDLL : public IHookableNameFilterOrdered
 	HOOK_DECL(qboolean, __cdecl, CL_ReadDemoMessage_OLD)
 	HOOK_DECL(void, __cdecl, LoadThisDll, const char* szDllFilename)
 
-	#ifdef HLSDK10_BUILD
-	struct server_static_t
-	{
-		int maxclients;
-		byte align[28684];
-		client_t *clients;
-	};
-	#else
-	struct server_static_t
-	{
-		int dll_initialized;
-		client_t *clients;
-		int maxclients;
-	};
-	#endif
-
 	struct Key
 	{
 		Key(const char* name) : State(0), Name(name) {};

--- a/BunnymodXT/stdafx.hpp
+++ b/BunnymodXT/stdafx.hpp
@@ -84,6 +84,7 @@ using std::ptrdiff_t;
 #include "HLSDK/pm_shared/pm_defs.h"
 
 #include "HLSDK/engine/usermsg.h"
+#include "HLSDK/engine/server_static.h"
 #include "HLSDK/engine/cdll_int.h"
 #include "HLSDK/engine/client.h"
 

--- a/HLSDK/engine/server_static.h
+++ b/HLSDK/engine/server_static.h
@@ -1,0 +1,20 @@
+#if !defined( SERVER_STATIC_H )
+#define SERVER_STATIC_H
+
+#ifdef HLSDK10_BUILD
+struct server_static_t
+{
+	int maxclients;
+	byte align[28684];
+	struct client_t *clients;
+};
+#else
+struct server_static_t
+{
+	int dll_initialized;
+	struct client_t *clients;
+	int maxclients;
+};
+#endif
+
+#endif


### PR DESCRIPTION
I don't like that these kinds of key structures are stored in a file that is not intended for them, which makes navigation a little worse through them.