### PR TITLE
helper_functions: added IsPlayer and Center own implementations to not rely on hooked virtual functions

### DIFF
--- a/BunnymodXT/helper_functions.cpp
+++ b/BunnymodXT/helper_functions.cpp
@@ -4,6 +4,30 @@
 
 namespace helper_functions
 {
+	bool IsPlayer(const edict_t *ent)
+	{
+		// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/player.cpp#L2850
+
+		auto &hw = HwDLL::GetInstance();
+		auto &sv = ServerDLL::GetInstance();
+
+		if (strcmp(hw.GetString(ent->v.classname), "player") != 0)
+			return false;
+
+		if (!(ent->v.flags & FL_CLIENT))
+			return false;
+
+		if (sv.pEngfuncs && hw.ppGlobals)
+		{
+			int index = sv.pEngfuncs->pfnIndexOfEdict(ent);
+
+			if ((index < 1) || (index > hw.ppGlobals->maxClients)) // gGlobalVariables.maxClients = svs.maxclients
+				return false;
+		}
+
+		return true;
+	}
+
 	void com_fixslashes(std::string &str)
 	{
 		// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/game_shared/bot/nav_file.cpp#L680

--- a/BunnymodXT/helper_functions.cpp
+++ b/BunnymodXT/helper_functions.cpp
@@ -4,6 +4,9 @@
 
 namespace helper_functions
 {
+	Vector Center(const Vector absmin, const Vector absmax) { return (absmin + absmax) * 0.5; }
+	Vector Center(const edict_t *ent) { return Center(ent->v.absmin, ent->v.absmax); }
+
 	bool IsPlayer(const edict_t *ent)
 	{
 		// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/player.cpp#L2850

--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -10,6 +10,10 @@
 
 namespace helper_functions
 {
+	// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/cbase.h#L336-L337
+	Vector Center(const Vector absmin, const Vector absmax);
+	Vector Center(const edict_t *ent);
+
 	bool IsPlayer(const edict_t *ent);
 
 	void com_fixslashes(std::string &str);

--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -10,6 +10,8 @@
 
 namespace helper_functions
 {
+	bool IsPlayer(const edict_t *ent);
+
 	void com_fixslashes(std::string &str);
 	std::string swap_lib(const char* current_lib_path, std::string new_lib_path, const char *start);
 	void crash_if_failed(std::string str);

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -6043,7 +6043,7 @@ void HwDLL::InsertCommands()
 
 						pushables[i].index = reinterpret_cast<uintptr_t>(pev);
 
-						Vector origin = pev->origin + ((pev->mins + pev->maxs) / 2.f);
+						Vector origin = helper_functions::Center(ent);
 						pushables[i].origin[0] = origin[0];
 						pushables[i].origin[1] = origin[1];
 						pushables[i].origin[2] = origin[2];
@@ -6067,8 +6067,7 @@ void HwDLL::InsertCommands()
 						StrafeState.Parameters.Parameters.LookAt.Entity = 0;
 					} else {				
 						const edict_t *ent = edicts + StrafeState.Parameters.Parameters.LookAt.Entity;
-						const entvars_t *pev = &(ent->v);
-						Vector origin = pev->origin + ((pev->mins + pev->maxs) / 2.f);
+						Vector origin = helper_functions::Center(ent);
 
 						StrafeState.TargetYawLookAtOrigin[0] = origin[0];
 						StrafeState.TargetYawLookAtOrigin[1] = origin[1];

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -2623,12 +2623,8 @@ bool ServerDLL::IsPlayerMovingPushable(const entvars_t *pevPushable, const entva
 	if (pevToucher->flags & FL_ONGROUND && pevToucher->groundentity && &pevToucher->groundentity->v == pevPushable)
 		return false;
 
-	/*
-	void *pToucher = pevToucher->pContainingEntity->pvPrivateData;
-	_IsPlayer IsPlayerFunc = *reinterpret_cast<_IsPlayer *>(*reinterpret_cast<uintptr_t *>(pToucher) + offFuncIsPlayer);
-	if (!IsPlayerFunc(pToucher))
+	if (!helper_functions::IsPlayer(pevToucher->pContainingEntity))
 		return false;
-	*/
 
 	if (push && !(pevToucher->button & (IN_FORWARD | IN_USE)))
 		return false;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -2690,19 +2690,10 @@ HOOK_DEF_6(ServerDLL, int, __fastcall, CBasePlayer__TakeDamage, void*, thisptr, 
 			damage.direction[1] = 0.0;
 			damage.direction[2] = 0.0;
 		} else {
-			/*
-			void *pInflictor = pevInflictor->pContainingEntity->pvPrivateData;
-			_Center playerCenterFunc = *reinterpret_cast<_Center *>(*reinterpret_cast<uintptr_t *>(thisptr) + offFuncCenter);
-			_Center inflictorCenterFunc = *reinterpret_cast<_Center *>(*reinterpret_cast<uintptr_t *>(pInflictor) + offFuncCenter);
+			entvars_t *pev = *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + 4); // _Smiley: TODO: replace it with GET_PEV macro once it's merged.
 
-			Vector playerCenter;
-			Vector inflictorCenter;
-			playerCenterFunc(thisptr, edx, &playerCenter);
-			inflictorCenterFunc(pInflictor, edx, &inflictorCenter);
-			*/
-
-			Vector playerCenter;
-			Vector inflictorCenter;
+			Vector playerCenter = helper_functions::Center(pev->pContainingEntity);
+			Vector inflictorCenter = helper_functions::Center(pevInflictor->pContainingEntity);
 			Vector vecDir = playerCenter + Vector(0, 0, 10) - inflictorCenter;
 
 			damage.direction[0] = vecDir.x;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -510,34 +510,28 @@ void ServerDLL::FindStuff()
 			case 3: // OP4-WON
 				offm_rgAmmoLast = 0x5C0;
 				offm_iClientFOV = 0x4A4;
-				offFuncCenter = 0xCC;
 				break;
 			case 4: // OpposingForce
 				offm_rgAmmoLast = 0x604;
 				offm_iClientFOV = 0x4E0;
-				offFuncCenter = 0xCC;
 				break;
 			case 5: // OP4-8684
 				offm_rgAmmoLast = 0x608;
 				offm_iClientFOV = 0x4E4;
-				offFuncCenter = 0xCC;
 				break;
 			case 6: // Gunman
 				offm_rgAmmoLast = 0x53C;
 				offm_iClientFOV = 0x47C;
-				offFuncCenter = 0xCC;
 				break;
 			case 7: // CSCZDS
 				offm_rgAmmoLast = 0x53C;
 				offm_iClientFOV = 0x898;
-				offFuncCenter = 0xDC;
 				offFuncObjectCaps = 0x18;
 				is_czeror = true;
 				break;
 			case 8: // CSCZDS-8684
 				offm_rgAmmoLast = 0x540;
 				offm_iClientFOV = 0x89C;
-				offFuncCenter = 0xDC;
 				offFuncObjectCaps = 0x18;
 				is_czeror = true;
 				break;
@@ -548,30 +542,25 @@ void ServerDLL::FindStuff()
 			case 10: // PARANOIA
 				offm_rgAmmoLast = 0x62C;
 				offm_iClientFOV = 0x584;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				break;
 			case 11: // CStrike-Latest
-				offFuncCenter = 0xCC;
 				offFuncObjectCaps = 0x18;
 				break;
 			case 12: // TFC-8684
 				offm_rgAmmoLast = 0x978;
 				offm_iClientFOV = 0x8CC;
-				offFuncCenter = 0xC4;
 				offFuncObjectCaps = 0x18;
 				break;
 			case 13: // TWHL-Tower-2
 			case 14: // Halfquake Trilogy
 				offm_rgAmmoLast = 0x5F4;
 				offm_iClientFOV = 0x548;
-				offFuncCenter = 0x100;
 				offFuncObjectCaps = 0x44;
 				break;
 			case 15: // Echoes
 				offm_rgAmmoLast = 0x5F4;
 				offm_iClientFOV = 0x548;
-				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
 			case 16: // Decay
@@ -586,7 +575,6 @@ void ServerDLL::FindStuff()
 			case 18: // Black-Ops
 				offm_rgAmmoLast = 0x554;
 				offm_iClientFOV = 0x4AC;
-				offFuncCenter = 0xD0;
 				break;
 			case 19: // Invasion
 				offm_rgAmmoLast = 0x514;
@@ -595,13 +583,11 @@ void ServerDLL::FindStuff()
 			case 20: // Arctic-Incident
 				offm_rgAmmoLast = 0x5B8;
 				offm_iClientFOV = 0x510;
-				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
 			case 21: // HL-Delta
 				offm_rgAmmoLast = 0x5C8;
 				offm_iClientFOV = 0x51C;
-				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
 			case 23: // OPBT
@@ -611,7 +597,6 @@ void ServerDLL::FindStuff()
 			case 24: // Parasomnia
 				offm_rgAmmoLast = 0x564;
 				offm_iClientFOV = 0x4B8;
-				offFuncCenter = 0xC4;
 				break;
 			case 26: // AVP2
 				offm_rgAmmoLast = 0x550;
@@ -620,7 +605,6 @@ void ServerDLL::FindStuff()
 			case 27: // CoF-Mod-10
 				offm_rgAmmoLast = 0x2440;
 				offm_iClientFOV = 0x238C;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2080;
 				offm_bInfiniteStamina = 0x2078;
@@ -632,7 +616,6 @@ void ServerDLL::FindStuff()
 			case 28: // CoF-Mod-11
 				offm_rgAmmoLast = 0x2444;
 				offm_iClientFOV = 0x2390;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2084;
 				offm_bInfiniteStamina = 0x207C;
@@ -644,7 +627,6 @@ void ServerDLL::FindStuff()
 			case 29: // CoF-Mod-12
 				offm_rgAmmoLast = 0x2450;
 				offm_iClientFOV = 0x239C;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2090;
 				offm_bInfiniteStamina = 0x2088;
@@ -657,7 +639,6 @@ void ServerDLL::FindStuff()
 			case 30: // CoF-Mod-13-135
 				offm_rgAmmoLast = 0x2460;
 				offm_iClientFOV = 0x23AC;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20A0;
 				offm_bInfiniteStamina = 0x2098;
@@ -670,7 +651,6 @@ void ServerDLL::FindStuff()
 			case 31: // CoF-Mod-14-155
 				offm_rgAmmoLast = 0x2464;
 				offm_iClientFOV = 0x23B0;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20A4;
 				offm_bInfiniteStamina = 0x209C;
@@ -683,7 +663,6 @@ void ServerDLL::FindStuff()
 			case 32: // CoF-Steam-Release
 				offm_rgAmmoLast = 0x2474;
 				offm_iClientFOV = 0x23C0;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20B4;
 				offm_bInfiniteStamina = 0x20AC;
@@ -695,7 +674,6 @@ void ServerDLL::FindStuff()
 			case 33: // CoF-Steam-Latest
 				offm_rgAmmoLast = 0x25C0;
 				offm_iClientFOV = 0x250C;
-				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x21F0;
 				offm_bInfiniteStamina = 0x21E8;
@@ -705,7 +683,6 @@ void ServerDLL::FindStuff()
 				is_cof = true;
 				break;
 			case 34: // DayOfDefeat-Latest
-				offFuncCenter = 0xE0;
 				offFuncObjectCaps = 0x20;
 				break;
 			case 35: // DeathmatchClassic-Latest
@@ -946,7 +923,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirContain("czeror")) {
 					offm_rgAmmoLast = 0x554; // 6153: 0x550
 					offm_iClientFOV = 0x8B0; // 6153: 0x8AC
-					offFuncCenter = 0xDC;
 					offFuncObjectCaps = 0x18;
 				}
 				if (ClientDLL::GetInstance().DoesGameDirContain("bshift")) {
@@ -956,7 +932,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirMatch("cstrike") || ClientDLL::GetInstance().DoesGameDirMatch("czero")) {
 					offm_rgAmmoLast = 0x674;
 					offm_iClientFOV = 0x5C4;
-					offFuncCenter = 0xCC;
 					offFuncObjectCaps = 0x18;
 				}
 				if (ClientDLL::GetInstance().DoesGameDirMatch("tfc")) {
@@ -967,7 +942,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirMatch("dod")) {
 					offm_rgAmmoLast = 0x4F8; // 6153: 0x4F4
 					offm_iClientFOV = 0x448; // 6153: 0x444
-					offFuncCenter = 0xE0;
 					offFuncObjectCaps = 0x20;
 				}
 				if (ClientDLL::GetInstance().DoesGameDirMatch("dmc")) {
@@ -2716,6 +2690,7 @@ HOOK_DEF_6(ServerDLL, int, __fastcall, CBasePlayer__TakeDamage, void*, thisptr, 
 			damage.direction[1] = 0.0;
 			damage.direction[2] = 0.0;
 		} else {
+			/*
 			void *pInflictor = pevInflictor->pContainingEntity->pvPrivateData;
 			_Center playerCenterFunc = *reinterpret_cast<_Center *>(*reinterpret_cast<uintptr_t *>(thisptr) + offFuncCenter);
 			_Center inflictorCenterFunc = *reinterpret_cast<_Center *>(*reinterpret_cast<uintptr_t *>(pInflictor) + offFuncCenter);
@@ -2724,6 +2699,10 @@ HOOK_DEF_6(ServerDLL, int, __fastcall, CBasePlayer__TakeDamage, void*, thisptr, 
 			Vector inflictorCenter;
 			playerCenterFunc(thisptr, edx, &playerCenter);
 			inflictorCenterFunc(pInflictor, edx, &inflictorCenter);
+			*/
+
+			Vector playerCenter;
+			Vector inflictorCenter;
 			Vector vecDir = playerCenter + Vector(0, 0, 10) - inflictorCenter;
 
 			damage.direction[0] = vecDir.x;

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -510,19 +510,16 @@ void ServerDLL::FindStuff()
 			case 3: // OP4-WON
 				offm_rgAmmoLast = 0x5C0;
 				offm_iClientFOV = 0x4A4;
-				offFuncIsPlayer = 0xA0;
 				offFuncCenter = 0xCC;
 				break;
 			case 4: // OpposingForce
 				offm_rgAmmoLast = 0x604;
 				offm_iClientFOV = 0x4E0;
-				offFuncIsPlayer = 0xA0;
 				offFuncCenter = 0xCC;
 				break;
 			case 5: // OP4-8684
 				offm_rgAmmoLast = 0x608;
 				offm_iClientFOV = 0x4E4;
-				offFuncIsPlayer = 0xA0;
 				offFuncCenter = 0xCC;
 				break;
 			case 6: // Gunman
@@ -533,7 +530,6 @@ void ServerDLL::FindStuff()
 			case 7: // CSCZDS
 				offm_rgAmmoLast = 0x53C;
 				offm_iClientFOV = 0x898;
-				offFuncIsPlayer = 0xA8;
 				offFuncCenter = 0xDC;
 				offFuncObjectCaps = 0x18;
 				is_czeror = true;
@@ -541,7 +537,6 @@ void ServerDLL::FindStuff()
 			case 8: // CSCZDS-8684
 				offm_rgAmmoLast = 0x540;
 				offm_iClientFOV = 0x89C;
-				offFuncIsPlayer = 0xA8;
 				offFuncCenter = 0xDC;
 				offFuncObjectCaps = 0x18;
 				is_czeror = true;
@@ -553,19 +548,16 @@ void ServerDLL::FindStuff()
 			case 10: // PARANOIA
 				offm_rgAmmoLast = 0x62C;
 				offm_iClientFOV = 0x584;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				break;
 			case 11: // CStrike-Latest
-				offFuncIsPlayer = 0xA0;
 				offFuncCenter = 0xCC;
 				offFuncObjectCaps = 0x18;
 				break;
 			case 12: // TFC-8684
 				offm_rgAmmoLast = 0x978;
 				offm_iClientFOV = 0x8CC;
-				offFuncIsPlayer = 0x98;
 				offFuncCenter = 0xC4;
 				offFuncObjectCaps = 0x18;
 				break;
@@ -573,14 +565,12 @@ void ServerDLL::FindStuff()
 			case 14: // Halfquake Trilogy
 				offm_rgAmmoLast = 0x5F4;
 				offm_iClientFOV = 0x548;
-				offFuncIsPlayer = 0xD4;
 				offFuncCenter = 0x100;
 				offFuncObjectCaps = 0x44;
 				break;
 			case 15: // Echoes
 				offm_rgAmmoLast = 0x5F4;
 				offm_iClientFOV = 0x548;
-				offFuncIsPlayer = 0xCC;
 				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
@@ -596,7 +586,6 @@ void ServerDLL::FindStuff()
 			case 18: // Black-Ops
 				offm_rgAmmoLast = 0x554;
 				offm_iClientFOV = 0x4AC;
-				offFuncIsPlayer = 0xA4;
 				offFuncCenter = 0xD0;
 				break;
 			case 19: // Invasion
@@ -606,14 +595,12 @@ void ServerDLL::FindStuff()
 			case 20: // Arctic-Incident
 				offm_rgAmmoLast = 0x5B8;
 				offm_iClientFOV = 0x510;
-				offFuncIsPlayer = 0xCC;
 				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
 			case 21: // HL-Delta
 				offm_rgAmmoLast = 0x5C8;
 				offm_iClientFOV = 0x51C;
-				offFuncIsPlayer = 0xCC;
 				offFuncCenter = 0xF8;
 				offFuncObjectCaps = 0x3C;
 				break;
@@ -624,7 +611,6 @@ void ServerDLL::FindStuff()
 			case 24: // Parasomnia
 				offm_rgAmmoLast = 0x564;
 				offm_iClientFOV = 0x4B8;
-				offFuncIsPlayer = 0x98;
 				offFuncCenter = 0xC4;
 				break;
 			case 26: // AVP2
@@ -634,7 +620,6 @@ void ServerDLL::FindStuff()
 			case 27: // CoF-Mod-10
 				offm_rgAmmoLast = 0x2440;
 				offm_iClientFOV = 0x238C;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2080;
@@ -647,7 +632,6 @@ void ServerDLL::FindStuff()
 			case 28: // CoF-Mod-11
 				offm_rgAmmoLast = 0x2444;
 				offm_iClientFOV = 0x2390;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2084;
@@ -660,7 +644,6 @@ void ServerDLL::FindStuff()
 			case 29: // CoF-Mod-12
 				offm_rgAmmoLast = 0x2450;
 				offm_iClientFOV = 0x239C;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x2090;
@@ -674,7 +657,6 @@ void ServerDLL::FindStuff()
 			case 30: // CoF-Mod-13-135
 				offm_rgAmmoLast = 0x2460;
 				offm_iClientFOV = 0x23AC;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20A0;
@@ -688,7 +670,6 @@ void ServerDLL::FindStuff()
 			case 31: // CoF-Mod-14-155
 				offm_rgAmmoLast = 0x2464;
 				offm_iClientFOV = 0x23B0;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20A4;
@@ -702,7 +683,6 @@ void ServerDLL::FindStuff()
 			case 32: // CoF-Steam-Release
 				offm_rgAmmoLast = 0x2474;
 				offm_iClientFOV = 0x23C0;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x20B4;
@@ -715,7 +695,6 @@ void ServerDLL::FindStuff()
 			case 33: // CoF-Steam-Latest
 				offm_rgAmmoLast = 0x25C0;
 				offm_iClientFOV = 0x250C;
-				offFuncIsPlayer = 0xD0;
 				offFuncCenter = 0xFC;
 				offFuncObjectCaps = 0x40;
 				offm_fStamina = 0x21F0;
@@ -726,7 +705,6 @@ void ServerDLL::FindStuff()
 				is_cof = true;
 				break;
 			case 34: // DayOfDefeat-Latest
-				offFuncIsPlayer = 0xB4;
 				offFuncCenter = 0xE0;
 				offFuncObjectCaps = 0x20;
 				break;
@@ -968,7 +946,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirContain("czeror")) {
 					offm_rgAmmoLast = 0x554; // 6153: 0x550
 					offm_iClientFOV = 0x8B0; // 6153: 0x8AC
-					offFuncIsPlayer = 0xA8;
 					offFuncCenter = 0xDC;
 					offFuncObjectCaps = 0x18;
 				}
@@ -979,7 +956,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirMatch("cstrike") || ClientDLL::GetInstance().DoesGameDirMatch("czero")) {
 					offm_rgAmmoLast = 0x674;
 					offm_iClientFOV = 0x5C4;
-					offFuncIsPlayer = 0xA0;
 					offFuncCenter = 0xCC;
 					offFuncObjectCaps = 0x18;
 				}
@@ -991,7 +967,6 @@ void ServerDLL::FindStuff()
 				if (ClientDLL::GetInstance().DoesGameDirMatch("dod")) {
 					offm_rgAmmoLast = 0x4F8; // 6153: 0x4F4
 					offm_iClientFOV = 0x448; // 6153: 0x444
-					offFuncIsPlayer = 0xB4;
 					offFuncCenter = 0xE0;
 					offFuncObjectCaps = 0x20;
 				}
@@ -2648,10 +2623,12 @@ bool ServerDLL::IsPlayerMovingPushable(const entvars_t *pevPushable, const entva
 	if (pevToucher->flags & FL_ONGROUND && pevToucher->groundentity && &pevToucher->groundentity->v == pevPushable)
 		return false;
 
+	/*
 	void *pToucher = pevToucher->pContainingEntity->pvPrivateData;
 	_IsPlayer IsPlayerFunc = *reinterpret_cast<_IsPlayer *>(*reinterpret_cast<uintptr_t *>(pToucher) + offFuncIsPlayer);
 	if (!IsPlayerFunc(pToucher))
 		return false;
+	*/
 
 	if (push && !(pevToucher->button & (IN_FORWARD | IN_USE)))
 		return false;

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -142,8 +142,6 @@ protected:
 	typedef void(__cdecl *_DispatchTouch)(edict_t *pentTouched, edict_t *pentOther);
 	_DispatchTouch ORIG_DispatchTouch;
 
-	typedef void (__fastcall *_Center)(void *thisptr, int edx, Vector *center);
-
 #ifdef _WIN32
 	typedef int (__fastcall *_ObjectCaps)(void *thisptr);
 #else
@@ -176,7 +174,6 @@ protected:
 
 	void *pGlobalState;
 
-	ptrdiff_t offFuncCenter = 0xC8;
 	ptrdiff_t offFuncObjectCaps = 0x14;
 
 	ptrdiff_t offNihilanthLevel;

--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -142,7 +142,6 @@ protected:
 	typedef void(__cdecl *_DispatchTouch)(edict_t *pentTouched, edict_t *pentOther);
 	_DispatchTouch ORIG_DispatchTouch;
 
-	typedef bool (__fastcall *_IsPlayer)(void *thisptr);
 	typedef void (__fastcall *_Center)(void *thisptr, int edx, Vector *center);
 
 #ifdef _WIN32
@@ -177,7 +176,6 @@ protected:
 
 	void *pGlobalState;
 
-	ptrdiff_t offFuncIsPlayer = 0x9C;
 	ptrdiff_t offFuncCenter = 0xC8;
 	ptrdiff_t offFuncObjectCaps = 0x14;
 


### PR DESCRIPTION
If you want an answer, is it really necessary to overloading the same function first with each individual argument, and then only with `edict_t` as an argument? I'll answer yes, because it solves two issues at once:

- In defense of `edict_t`: you can simply give only the edict as input, and the rest the function will do everything for you, wonderful, isn’t it?
- In defense of the function with each separate argument: this also allows for use in client code, for example, where you can get similar information but not with `edict_t`

Also In case someone wants to merge it if I would inactive for a while: simply rebase to the latest master as soon as https://github.com/YaLTeR/BunnymodXT/pull/531 is merged to solve the build errors