### PR TITLE
helper_functions: allow multiple instances on Windows

### DIFF
--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -13,4 +13,20 @@ namespace helper_functions
 	void com_fixslashes(std::string &str);
 	std::string swap_lib(const char* current_lib_path, std::string new_lib_path, const char *start);
 	void crash_if_failed(std::string str);
+
+	inline void allow_multiple_instances() // Make it possible to run multiple Half-Life instances.
+	{
+		#ifdef _WIN32
+		auto mutex = OpenMutexA(SYNCHRONIZE, FALSE, "ValveHalfLifeLauncherMutex");
+		if (!mutex)
+			mutex = OpenMutexA(SYNCHRONIZE, FALSE, "SvenCoopLauncherMutex");
+
+		if (mutex) 
+		{
+			EngineMsg("Releasing the launcher mutex.\n");
+			ReleaseMutex(mutex);
+			CloseHandle(mutex);
+		}
+		#endif
+	}
 }

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -376,15 +376,7 @@ void HwDLL::Hook(const std::wstring& moduleName, void* moduleHandle, void* modul
 	}
 	m_HookedNumber = number;
 
-#ifdef _WIN32
-	// Make it possible to run multiple Half-Life instances.
-	auto mutex = OpenMutexA(SYNCHRONIZE, FALSE, "ValveHalfLifeLauncherMutex");
-	if (mutex) {
-		EngineMsg("Releasing the launcher mutex.\n");
-		ReleaseMutex(mutex);
-		CloseHandle(mutex);
-	}
-#endif
+	helper_functions::allow_multiple_instances();
 
 	FindStuff();
 


### PR DESCRIPTION
Simply moved code from HwDLL to helper_functions for more convenient management

The only new change is that now it’s handled for Sven Co-op too