### PR TITLE
helper_functions: disable V-Sync

### DIFF
--- a/BunnymodXT/helper_functions.cpp
+++ b/BunnymodXT/helper_functions.cpp
@@ -40,4 +40,24 @@ namespace helper_functions
 
 		std::exit(1);
 	}
+
+	void disable_vsync()
+	{
+		#ifdef _WIN32
+		auto &hw = HwDLL::GetInstance();
+		if (hw.check_vsync)
+		{
+			const bool bxtDisableVSync = getenv("BXT_DISABLE_VSYNC");
+			if (bxtDisableVSync)
+			{
+				typedef BOOL(APIENTRY* PFNWGLSWAPINTERVALPROC)(int);
+				PFNWGLSWAPINTERVALPROC wglSwapIntervalEXT = 0;
+				wglSwapIntervalEXT = (PFNWGLSWAPINTERVALPROC)wglGetProcAddress("wglSwapIntervalEXT");
+				if (wglSwapIntervalEXT)
+					wglSwapIntervalEXT(0);
+			}
+			hw.check_vsync = false;
+		}
+		#endif
+	}
 };

--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -13,4 +13,5 @@ namespace helper_functions
 	void com_fixslashes(std::string &str);
 	std::string swap_lib(const char* current_lib_path, std::string new_lib_path, const char *start);
 	void crash_if_failed(std::string str);
+	void disable_vsync();
 }

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -11,6 +11,7 @@
 #include "../hud_custom.hpp"
 #include "../triangle_drawing.hpp"
 #include "../discord_integration.hpp"
+#include "../helper_functions.hpp"
 #include <GL/gl.h>
 
 // Linux hooks.
@@ -1667,22 +1668,7 @@ HOOK_DEF_1(ClientDLL, void, __cdecl, HUD_Frame, double, time)
 		orig_forcehltv_found = HwDLL::GetInstance().ORIG_Cmd_FindCmd("dem_forcehltv");
 	}
 
-	#ifdef _WIN32
-	static bool check_vsync = true;
-	if (check_vsync)
-	{
-		bool bxtDisableVSync = getenv("BXT_DISABLE_VSYNC");
-		if (bxtDisableVSync)
-		{
-			typedef BOOL(APIENTRY* PFNWGLSWAPINTERVALPROC)(int);
-			PFNWGLSWAPINTERVALPROC wglSwapIntervalEXT = 0;
-			wglSwapIntervalEXT = (PFNWGLSWAPINTERVALPROC)wglGetProcAddress("wglSwapIntervalEXT");
-			if (wglSwapIntervalEXT)
-				wglSwapIntervalEXT(0);
-		}
-		check_vsync = false;
-	}
-	#endif
+	helper_functions::disable_vsync();
 
 	if (CVars::_bxt_taslog.GetBool() && pEngfuncs)
 		pEngfuncs->Con_Printf(const_cast<char*>("HUD_Frame time: %f\n"), time);

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -764,6 +764,7 @@ void HwDLL::Clear()
 	pcl = nullptr;
 	cls = nullptr;
 	psv = nullptr;
+	check_vsync = true;
 	lastRecordedHealth = 0;
 	offTime = 0;
 	offWorldmodel = 0;

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -370,6 +370,8 @@ public:
 
 	int tas_studio_norefresh_override = 0;
 
+	bool check_vsync = true;
+
 private:
 	// Make sure to have hl.exe last here, so that it is the lowest priority.
 	HwDLL() : IHookableNameFilterOrdered({ L"hw.dll", L"hw.so", L"sw.dll", L"sw.so", L"hl.exe" }) {};


### PR DESCRIPTION
Simply moved code from HwDLL to helper_functions for more convenient management

The only new change is that `check_vsync` is no longer just a private variable, but a public one
This is used to reset the value to default in case the engine module might needs to be re-initialized (reset code in the `HwDLL::Clear` function)