### PR TITLE
helper_functions: added IsBSPModel and get_origin_of_entity functions

### DIFF
--- a/BunnymodXT/helper_functions.cpp
+++ b/BunnymodXT/helper_functions.cpp
@@ -50,4 +50,13 @@ namespace helper_functions
 
 		std::exit(1);
 	}
+
+	Vector get_origin_of_entity(const edict_t* ent)
+	{
+		Vector origin = ent->v.origin;
+		if (IsBSPModel(ent))
+			origin = Center(ent);
+
+		return origin;
+	}
 };

--- a/BunnymodXT/helper_functions.cpp
+++ b/BunnymodXT/helper_functions.cpp
@@ -4,6 +4,16 @@
 
 namespace helper_functions
 {
+	bool IsBSPModel(const int solid, const int movetype)
+	{
+		if ((solid == SOLID_BSP) || (movetype == MOVETYPE_PUSHSTEP))
+			return true;
+
+		return false;
+	}
+
+	bool IsBSPModel(const edict_t *ent) { return IsBSPModel(ent->v.solid, ent->v.movetype); }
+
 	void com_fixslashes(std::string &str)
 	{
 		// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/game_shared/bot/nav_file.cpp#L680

--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -17,4 +17,5 @@ namespace helper_functions
 	void com_fixslashes(std::string &str);
 	std::string swap_lib(const char* current_lib_path, std::string new_lib_path, const char *start);
 	void crash_if_failed(std::string str);
+	Vector get_origin_of_entity(const edict_t* ent);
 }

--- a/BunnymodXT/helper_functions.hpp
+++ b/BunnymodXT/helper_functions.hpp
@@ -10,6 +10,10 @@
 
 namespace helper_functions
 {
+	// https://github.com/ValveSoftware/halflife/blob/c7240b965743a53a29491dd49320c88eecf6257b/dlls/cbase.h#L197-L198
+	bool IsBSPModel(const int solid, const int movetype);
+	bool IsBSPModel(const edict_t *ent);
+
 	void com_fixslashes(std::string &str);
 	std::string swap_lib(const char* current_lib_path, std::string new_lib_path, const char *start);
 	void crash_if_failed(std::string str);

--- a/BunnymodXT/hud_custom.cpp
+++ b/BunnymodXT/hud_custom.cpp
@@ -883,8 +883,7 @@ namespace CustomHud
 				{
 					out << "Yaw: " << ent->v.angles[1] << '\n';
 
-					Vector origin;
-					HwDLL::GetInstance().GetOriginOfEntity(origin, ent);
+					Vector origin = helper_functions::get_origin_of_entity(ent);
 
 					out << "X: " << origin.x << '\n';
 					out << "Y: " << origin.y << '\n';

--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -4628,8 +4628,7 @@ void HwDLL::PrintEntity(std::ostringstream &out, int index)
 	if ((!strncmp(classname, "func_door", 9)) || (!strncmp(classname, "func_rotating", 13)) || (!strncmp(classname, "func_train", 10)))
 		out << "; dmg: " << ent->v.dmg;
 
-	Vector origin;
-	HwDLL::GetInstance().GetOriginOfEntity(origin, ent);
+	Vector origin = helper_functions::get_origin_of_entity(ent);
 
 	out << "; xyz: " << origin.x << " " << origin.y << " " << origin.z;
 
@@ -4777,22 +4776,6 @@ struct HwDLL::Cmd_BXT_Print_Entities_By_Index
 	}
 };
 
-void HwDLL::GetOriginOfEntity(Vector& origin, const edict_t* ent)
-{
-	const auto& hw = HwDLL::GetInstance();
-	const char* classname = hw.GetString(ent->v.classname);
-	bool is_trigger = std::strncmp(classname, "trigger_", 8) == 0;
-	bool is_ladder = std::strncmp(classname, "func_ladder", 11) == 0;
-	bool is_friction = std::strncmp(classname, "func_friction", 13) == 0;
-	bool is_water = std::strncmp(classname, "func_water", 10) == 0;
-
-	// Credits to 'goldsrc_monitor' tool for their code to get origin of entities
-	if (ent->v.solid == SOLID_BSP || ent->v.movetype == MOVETYPE_PUSHSTEP || is_trigger || is_ladder || is_friction || is_water)
-		origin = ent->v.origin + ((ent->v.mins + ent->v.maxs) / 2.f);
-	else
-		origin = ent->v.origin;
-}
-
 struct HwDLL::Cmd_BXT_CH_Teleport_To_Entity
 {
 	USAGE("Usage: bxt_ch_teleport_to_entity <index>\n");
@@ -4817,8 +4800,7 @@ struct HwDLL::Cmd_BXT_CH_Teleport_To_Entity
 			return;
 		}
 
-		Vector origin;
-		HwDLL::GetInstance().GetOriginOfEntity(origin, ent);
+		Vector origin = helper_functions::get_origin_of_entity(ent);
 
 		(*hw.sv_player)->v.origin[0] = origin[0];
 		(*hw.sv_player)->v.origin[1] = origin[1];

--- a/BunnymodXT/modules/HwDLL.hpp
+++ b/BunnymodXT/modules/HwDLL.hpp
@@ -551,7 +551,6 @@ protected:
 public:
 	HLStrafe::MovementVars GetMovementVars();
 	const char* GetMovetypeName(int moveType);
-	void GetOriginOfEntity(Vector& origin, const edict_t* ent);
 
 	bool ducktap;
 	edict_t **sv_player;


### PR DESCRIPTION
Rebase after #540 is merged

`IsBSPModel` - function from HLSDK to determine if it is brush entity or not

`get_origin_of_entity` - custom function to get origin based on if it is brush entity or not (but this does not work correctly with some entities, e.g. `trigger_`, because those coordinates are also based on the center point, but the `IsBSPModel` from HLSDK does not take them into account, and I don’t want to use hacks yet for that because this is not really necessary for the current code)