### PR TITLE
pre/post: reworked changes in AddToFullPack for correctness and portability

### DIFF
--- a/BunnymodXT/modules/ServerDLL.hpp
+++ b/BunnymodXT/modules/ServerDLL.hpp
@@ -122,6 +122,8 @@ public:
 
 	bool IsPlayer(edict_t *ent);
 
+	void AddToFullPack_Pre(edict_t *ent, unsigned char **pSet, int &status);
+
 private:
 	ServerDLL() : IHookableDirFilter({ L"dlls", L"cl_dlls"}) {};
 	ServerDLL(const ServerDLL&);

--- a/BunnymodXT/shared.hpp
+++ b/BunnymodXT/shared.hpp
@@ -50,3 +50,13 @@ constexpr steamid_t STEAMID64_CONST = 76561197960265728; // 0x110000100000000
 
 // - Custom macros
 #define GET_PEV(thisptr) *reinterpret_cast<entvars_t**>(reinterpret_cast<uintptr_t>(thisptr) + off_pev);
+#define SET_OR_UNSET_FLAG(boolVar, setVar, flag) boolVar ? (setVar |= flag) : (setVar &= ~flag);
+
+// - Custom enums
+typedef enum
+{
+	BXT_ADDTOFULLPACK_STATE_NO = 0,
+	BXT_ADDTOFULLPACK_STATE_HIDDEN_ENTITIES,
+	BXT_ADDTOFULLPACK_STATE_HIDDEN_ENTITIES_CLIENTSIDE,
+	BXT_ADDTOFULLPACK_STATE_TRIGGERS
+} BXT_ENUM_ADDTOFULLPACK;


### PR DESCRIPTION
Three reasons why this request exists:

- In HLSDK 1.0-based engines and game directories, AddToFullPack is not in the server-side (hl.dll), but in the engine (hw.dll) under the name `SV_AddToFullPack`

So using such a pre/post implementation, we can easily make the same changes in several similar functions, i.e. no need to stupidly copy-paste the code every time

- We return old states only when they have actually been changed, thereby removing the possibility of accidentally overwriting the new state for objects to which we should not even make changes!

- For integer variables that serve to store flags for performing bitwise operations with them, we now return not their entire old state, but only the old state of a specific flag that we changed!