### PR TITLE
COF_BUILD: added donator fields in clientdata_t and usercmd_t structures

### DIFF
--- a/HLSDK/common/entity_state.h
+++ b/HLSDK/common/entity_state.h
@@ -229,6 +229,10 @@ typedef struct clientdata_s
 	vec3_t				vuser2;
 	vec3_t				vuser3;
 	vec3_t				vuser4;
+
+	#ifdef COF_BUILD
+	qboolean isdonator; // The data type is unknown, but to me it is clearly qboolean.
+	#endif
 } clientdata_t;
 
 #include "weaponinfo.h"

--- a/HLSDK/common/usercmd.h
+++ b/HLSDK/common/usercmd.h
@@ -36,6 +36,10 @@ typedef struct usercmd_s
 	// Experimental player impact stuff.
 	int		impact_index;
 	vec3_t	impact_position;
+
+	#ifdef COF_BUILD
+	qboolean is_donator; // The data type is unknown, but to me it is clearly qboolean.
+	#endif
 } usercmd_t;
 
 #endif // USERCMD_H


### PR DESCRIPTION
I don't have time to review previous requests, hope everything would be stable for me close to start of winter, but I pushed this request as a hotfix before the release.
I did it right now via the web interface instead of how I usually do it with `Git CMD` due to circumstances, I hope everything is OK with the commit history. DON'T EXPECT FROM ME REBASE OR SOMETHING RIGHT NOW.

If you want to know how to find these fields, I'll tell you:
- Create a **delta_definition_t** struct or import `delta.h` header in hw.dll from CoF in Ghidra/IDA Pro
- Find the `DELTA_Init` function, the code there will look like this:

```cpp
void FUN_01d5224b(void)
{
  FUN_01d44eff(s_delta_stats_01eb399c,FUN_01d52208);
  FUN_01d44eff(s_delta_clear_01eb39a8,FUN_01d52135);
  FUN_01d51a7a(s_clientdata_t_01eb39b4,g_ClientDataDefinition,0x39);
  FUN_01d51a7a(s_weapon_data_t_01eb39c4,g_WeaponDataDefinition,0x16);
  FUN_01d51a7a(s_usercmd_t_01eb39d4,g_UsercmdDataDefinition,0x11);
  FUN_01d51a7a(s_entity_state_t_01eb39e0,g_EntityDataDefinition,0x57);
  FUN_01d51a7a(s_entity_state_player_t_01eb39f0,g_EntityDataDefinition,0x57);
  FUN_01d51a7a(s_custom_entity_state_t_01eb3a08,g_EntityDataDefinition,0x57);
  FUN_01d51a7a(s_event_t_01eb3a20,&PTR_s_entindex_01eb23b0,0xe);
  return;
```

- I renamed the g_ variables myself, by default you won't have it. 
- But the point is that by default they will have a garbage data type for obvious reasons, but you should reassign them to `delta_definition_t globalvariable[ARRAYSIZE]`
- You can take the ARRAYSIZE from the last argument of the function. For example, `g_ClientDataDefinition` has an array size of 0x39 (57)
- Therefore, you assign `delta_definition_t g_ClientDataDefinition[57]`.

After which you simply compare it with the data in the GoldSrc engine and make changes in your headers due to the corresponding fields.