### PR TITLE
fixed selfgauss debug and other trace problem

### DIFF
--- a/BunnymodXT/modules/HwDLL.cpp
+++ b/BunnymodXT/modules/HwDLL.cpp
@@ -3011,23 +3011,28 @@ struct HwDLL::Cmd_BXT_Get_Origin_And_Angles
 	static void handler()
 	{
 		auto &hw = HwDLL::GetInstance();
-		auto &cl = ClientDLL::GetInstance();
-		auto &sv = ServerDLL::GetInstance();
-		float angles[3];
-		cl.pEngfuncs->GetViewAngles(angles);
+		if (hw.GetPlayerEdict())
+		{
+			auto& cl = ClientDLL::GetInstance();
+			auto& sv = ServerDLL::GetInstance();
+			float angles[3];
+			cl.pEngfuncs->GetViewAngles(angles);
 
-		float view[3], end[3];
-		cl.SetupTraceVectors(view, end);
-		const auto tr = sv.TraceLine(view, end, 0, hw.GetPlayerEdict());
+			float view[3], end[3];
+			cl.SetupTraceVectors(view, end);
+			const auto tr = sv.TraceLine(view, end, 0, hw.GetPlayerEdict());
 
-		hw.ORIG_Con_Printf("bxt_set_angles %f %f %f;", angles[0], angles[1], angles[2]);
-		if (CVars::bxt_hud_origin.GetInt() == 2)
-			hw.ORIG_Con_Printf("bxt_ch_set_pos %f %f %f\n", cl.last_vieworg[0], cl.last_vieworg[1], cl.last_vieworg[2]);
+			hw.ORIG_Con_Printf("bxt_set_angles %f %f %f;", angles[0], angles[1], angles[2]);
+			if (CVars::bxt_hud_origin.GetInt() == 2)
+				hw.ORIG_Con_Printf("bxt_ch_set_pos %f %f %f\n", cl.last_vieworg[0], cl.last_vieworg[1], cl.last_vieworg[2]);
+			else
+				hw.ORIG_Con_Printf("bxt_ch_set_pos %f %f %f\n", (*hw.sv_player)->v.origin[0], (*hw.sv_player)->v.origin[1], (*hw.sv_player)->v.origin[2]);
+
+			hw.ORIG_Con_Printf("bxt_cam_fixed %f %f %f %f %f %f\n", cl.last_vieworg[0], cl.last_vieworg[1], cl.last_vieworg[2], angles[0], angles[1], angles[2]);
+			hw.ORIG_Con_Printf("Traced point origin: %f %f %f\n", tr.vecEndPos[0], tr.vecEndPos[1], tr.vecEndPos[2]);
+		}
 		else
-			hw.ORIG_Con_Printf("bxt_ch_set_pos %f %f %f\n", (*hw.sv_player)->v.origin[0], (*hw.sv_player)->v.origin[1], (*hw.sv_player)->v.origin[2]);
-
-		hw.ORIG_Con_Printf("bxt_cam_fixed %f %f %f %f %f %f\n", cl.last_vieworg[0], cl.last_vieworg[1], cl.last_vieworg[2], angles[0], angles[1], angles[2]);
-		hw.ORIG_Con_Printf("Traced point origin: %f %f %f\n", tr.vecEndPos[0], tr.vecEndPos[1], tr.vecEndPos[2]);
+			hw.ORIG_Con_Printf("Player doesn't exist");
 	}
 };
 
@@ -3181,14 +3186,16 @@ struct HwDLL::Cmd_BXT_CH_Entity_Set_Health
 		const auto& serv = ServerDLL::GetInstance();
 		float view[3], end[3];
 		ClientDLL::GetInstance().SetupTraceVectors(view, end);
-
-		const auto tr = serv.TraceLine(view, end, 0, HwDLL::GetInstance().GetPlayerEdict());
-
-		if (tr.pHit)
+		if (HwDLL::GetInstance().GetPlayerEdict())
 		{
-			const auto ent = tr.pHit;
+			const auto tr = serv.TraceLine(view, end, 0, HwDLL::GetInstance().GetPlayerEdict());
 
-			ent->v.health = hp;
+			if (tr.pHit)
+			{
+				const auto ent = tr.pHit;
+
+				ent->v.health = hp;
+			}
 		}
 	}
 
@@ -3290,17 +3297,19 @@ struct HwDLL::Cmd_BXT_CH_Monster_Set_Origin
 		const auto& serv = ServerDLL::GetInstance();
 		float view[3], end[3];
 		ClientDLL::GetInstance().SetupTraceVectors(view, end);
-
-		const auto tr = serv.TraceLine(view, end, 0, HwDLL::GetInstance().GetPlayerEdict());
-
-		if (tr.pHit)
+		if (HwDLL::GetInstance().GetPlayerEdict())
 		{
-			const auto ent = tr.pHit;
-			if (ent->v.flags & FL_MONSTER)
+			const auto tr = serv.TraceLine(view, end, 0, HwDLL::GetInstance().GetPlayerEdict());
+
+			if (tr.pHit)
 			{
-				ent->v.origin[0] = x;
-				ent->v.origin[1] = y;
-				ent->v.origin[2] = z;
+				const auto ent = tr.pHit;
+				if (ent->v.flags & FL_MONSTER)
+				{
+					ent->v.origin[0] = x;
+					ent->v.origin[1] = y;
+					ent->v.origin[2] = z;
+				}
 			}
 		}
 	}

--- a/BunnymodXT/modules/ServerDLL.cpp
+++ b/BunnymodXT/modules/ServerDLL.cpp
@@ -3002,7 +3002,7 @@ TraceResult ServerDLL::TraceLine(const float v1[3], const float v2[3], int fNoMo
 {
 	TraceResult tr{};
 
-	if (pEngfuncs && pentToSkip)
+	if (pEngfuncs)
 		pEngfuncs->pfnTraceLine(v1, v2, fNoMonsters, pentToSkip, &tr);
 
 	return tr;


### PR DESCRIPTION
bxt_hud_selfgauss
* 2 and below show singleplayer behavior
* 3 and above show multiplayer behavior
* Even numbers show coordinates of line traces
* All reasons for failing to selfgauss are now shown
* Threshold translated to time value, more intuitive
* Hit group display may have been broken before, definitely works now

to fix bxt_hud_selfgauss not working correctly, one condition was removed from ServerDLL::TraceLine. this needs to be removed or else the 2nd and 3rd line traces incorrectly say they hit an object at 0, 0, 0.

since the condition was added to avoid a crash when playing a demo in bxt_hud_entity_info, all places that used a trace involving the player will now exit harmlessly if the player entity doesn't exist