### PR TITLE
add livesplit delta for in-game pace

### DIFF
--- a/BunnymodXT/Linux/interprocess.cpp
+++ b/BunnymodXT/Linux/interprocess.cpp
@@ -127,4 +127,8 @@ namespace Interprocess
 	void WriteBSALeapOfFaith(const Time& time)
 	{
 	}
+
+	std::string ReadLastSplitDelta() {
+		return "-";
+	}
 }

--- a/BunnymodXT/cvars.hpp
+++ b/BunnymodXT/cvars.hpp
@@ -243,7 +243,10 @@
 	X(bxt_ch_trigger_tp_keeps_momentum_velocity, "1") \
 	X(bxt_ch_trigger_tp_keeps_momentum_velocity_redirect, "0") \
 	X(bxt_ch_trigger_tp_keeps_momentum_viewangles, "1") \
-	X(bxt_ch_trigger_tp_landmark, "0")
+	X(bxt_ch_trigger_tp_landmark, "0") \
+	X(bxt_livesplit_last_delta, "0") \
+	X(bxt_livesplit_last_delta_offset, "") \
+	X(bxt_livesplit_last_delta_anchor, "")
 
 class CVarWrapper
 {

--- a/BunnymodXT/interprocess.hpp
+++ b/BunnymodXT/interprocess.hpp
@@ -24,4 +24,6 @@ namespace Interprocess
 	void WriteTimerReset(const Time& time);
 	void WriteTimerStart(const Time& time);
 	void WriteBSALeapOfFaith(const Time& time);
+
+	std::string ReadLastSplitDelta();
 }

--- a/BunnymodXT/modules/ClientDLL.cpp
+++ b/BunnymodXT/modules/ClientDLL.cpp
@@ -1071,6 +1071,9 @@ void ClientDLL::RegisterCVarsAndCommands()
 		REG(bxt_hud_split_anchor);
 		REG(bxt_hud_split_duration);
 		REG(bxt_hud_split_fadeout);
+		REG(bxt_livesplit_last_delta);
+		REG(bxt_livesplit_last_delta_offset);
+		REG(bxt_livesplit_last_delta_anchor);
 	}
 
 	if (ORIG_HUD_Redraw) {

--- a/BunnymodXT/shared.hpp
+++ b/BunnymodXT/shared.hpp
@@ -18,6 +18,7 @@ enum class EventType : unsigned char {
 
 #define MQ_NAME "BunnymodXT-TASView"
 #define BUNNYSPLIT_PIPE_NAME "BunnymodXT-BunnySplit"
+#define LIVESPLIT_PIPE_NAME "LiveSplit"
 
 // - Game constants
 // Constants that are taken from the game code and you don't want to add for them the corresponding header, then leave them here.


### PR DESCRIPTION
Adds _bxt_livesplit_last_delta_ with position variables to see the live pace information in-game.
It was suggested as a nice feature for those playing fullscreened with only 1 monitor who can't always see their splits.

It wasn't super clear if BunnySplit had facilities for this so it includes setting up another named pipe to query the livesplit server.